### PR TITLE
Add a 'serde_svd' feature which adds serde derive macros.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,10 @@ version = "0.7.0"
 
 [features]
 unproven = []
+serde_svd = ["serde"]
 
 [dependencies]
 either = "1.1.0"
 xmltree = "0.3.2"
 failure = "0.1.1"
+serde = { version = "1.0", features = [ "derive" ], optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,7 +69,7 @@ pub enum InvalidBitRange {
 }
 
 impl Fail for SVDError {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&(dyn Fail)> {
         self.inner.cause()
     }
 

--- a/src/svd/access.rs
+++ b/src/svd/access.rs
@@ -8,6 +8,10 @@ use error::*;
 use new_element;
 use types::Parse;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Access {
     ReadOnly,

--- a/src/svd/addressblock.rs
+++ b/src/svd/addressblock.rs
@@ -12,6 +12,10 @@ use error::SVDError;
 #[cfg(feature = "unproven")]
 use new_element;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AddressBlock {
     pub offset: u32,

--- a/src/svd/bitrange.rs
+++ b/src/svd/bitrange.rs
@@ -6,6 +6,10 @@ use error::*;
 use new_element;
 use types::Parse;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BitRange {
     pub offset: u32,
@@ -13,6 +17,7 @@ pub struct BitRange {
     pub range_type: BitRangeType,
 }
 
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BitRangeType {
     BitRange,

--- a/src/svd/cluster.rs
+++ b/src/svd/cluster.rs
@@ -11,6 +11,10 @@ use error::*;
 use svd::clusterinfo::ClusterInfo;
 use svd::registerclusterarrayinfo::RegisterClusterArrayInfo;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Cluster {
     Single(ClusterInfo),

--- a/src/svd/clusterinfo.rs
+++ b/src/svd/clusterinfo.rs
@@ -13,6 +13,10 @@ use error::SVDError;
 use svd::access::Access;
 use svd::registercluster::RegisterCluster;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ClusterInfo {
     pub name: String,

--- a/src/svd/cpu.rs
+++ b/src/svd/cpu.rs
@@ -12,6 +12,10 @@ use new_element;
 use svd::endian::Endian;
 use types::Parse;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Cpu {
     pub name: String,

--- a/src/svd/defaults.rs
+++ b/src/svd/defaults.rs
@@ -12,7 +12,11 @@ use types::Parse;
 
 use svd::access::Access;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
 /// Register default properties
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Defaults {
     pub size: Option<u32>,

--- a/src/svd/device.rs
+++ b/src/svd/device.rs
@@ -15,6 +15,10 @@ use svd::cpu::Cpu;
 use svd::defaults::Defaults;
 use svd::peripheral::Peripheral;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug)]
 pub struct Device {
     pub name: String,

--- a/src/svd/endian.rs
+++ b/src/svd/endian.rs
@@ -10,6 +10,10 @@ use types::Parse;
 
 use error::*;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Endian {
     Little,

--- a/src/svd/enumeratedvalue.rs
+++ b/src/svd/enumeratedvalue.rs
@@ -13,6 +13,10 @@ use error::*;
 use new_element;
 use types::Parse;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct EnumeratedValue {
     pub name: String,

--- a/src/svd/enumeratedvalues.rs
+++ b/src/svd/enumeratedvalues.rs
@@ -15,6 +15,10 @@ use svd::enumeratedvalue::EnumeratedValue;
 use svd::usage::Usage;
 use types::Parse;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct EnumeratedValues {
     pub name: Option<String>,

--- a/src/svd/field.rs
+++ b/src/svd/field.rs
@@ -19,6 +19,10 @@ use svd::enumeratedvalues::EnumeratedValues;
 use svd::modifiedwritevalues::ModifiedWriteValues;
 use svd::writeconstraint::WriteConstraint;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Field {
     pub name: String,

--- a/src/svd/interrupt.rs
+++ b/src/svd/interrupt.rs
@@ -13,6 +13,10 @@ use error::*;
 use new_element;
 use types::Parse;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Interrupt {
     pub name: String,

--- a/src/svd/mod.rs
+++ b/src/svd/mod.rs
@@ -1,5 +1,7 @@
 //! SVD objects.
 //! This module defines components of an SVD along with parse and encode implementations
+#[cfg(feature = "serde_svd")]
+extern crate serde;
 
 pub mod endian;
 pub use self::endian::Endian;

--- a/src/svd/modifiedwritevalues.rs
+++ b/src/svd/modifiedwritevalues.rs
@@ -9,6 +9,10 @@ use types::Parse;
 use encode::Encode;
 use error::*;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ModifiedWriteValues {
     OneToClear,

--- a/src/svd/peripheral.rs
+++ b/src/svd/peripheral.rs
@@ -18,6 +18,10 @@ use svd::addressblock::AddressBlock;
 use svd::interrupt::Interrupt;
 use svd::registercluster::RegisterCluster;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug)]
 pub struct Peripheral {
     pub name: String,

--- a/src/svd/register.rs
+++ b/src/svd/register.rs
@@ -12,6 +12,10 @@ use error::SVDError;
 use svd::registerclusterarrayinfo::RegisterClusterArrayInfo;
 use svd::registerinfo::RegisterInfo;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Register {
     Single(RegisterInfo),

--- a/src/svd/registercluster.rs
+++ b/src/svd/registercluster.rs
@@ -9,6 +9,10 @@ use error::{SVDError, SVDErrorKind};
 use svd::cluster::Cluster;
 use svd::register::Register;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum RegisterCluster {
     Register(Register),

--- a/src/svd/registerclusterarrayinfo.rs
+++ b/src/svd/registerclusterarrayinfo.rs
@@ -10,6 +10,10 @@ use new_element;
 
 use error::SVDError;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RegisterClusterArrayInfo {
     pub dim: u32,

--- a/src/svd/registerinfo.rs
+++ b/src/svd/registerinfo.rs
@@ -18,6 +18,10 @@ use svd::field::Field;
 use svd::modifiedwritevalues::ModifiedWriteValues;
 use svd::writeconstraint::WriteConstraint;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RegisterInfo {
     pub name: String,

--- a/src/svd/usage.rs
+++ b/src/svd/usage.rs
@@ -9,6 +9,10 @@ use encode::Encode;
 use error::*;
 use types::Parse;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Usage {
     Read,

--- a/src/svd/writeconstraint.rs
+++ b/src/svd/writeconstraint.rs
@@ -11,6 +11,10 @@ use error::*;
 use new_element;
 use types::Parse;
 
+#[cfg(feature = "serde_svd")]
+use super::serde::{ Deserialize, Serialize };
+
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WriteConstraint {
     WriteAsRead(bool),
@@ -18,6 +22,7 @@ pub enum WriteConstraint {
     Range(WriteConstraintRange),
 }
 
+#[cfg_attr(feature = "serde_svd", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WriteConstraintRange {
     pub min: u32,


### PR DESCRIPTION
I found myself wanting to use `svd2rust` to parse SVD files into a JSON format, but it looks like this underlying `svd` crate doesn't support the `serde` Serialize / Deserialize macros which are used by a variety of Rust parsers and formatters.

Adding conditional `#[derive(Deserialize, Serialize)]` attributes to this crate seemed easier than creating a new crate with duplicate structs, and I put it behind an optional feature because most use cases won't require `serde` support.

Anyways, no worries if this addition is not within the scope of this crate, but I thought I'd share since it seems to work. Example project:

https://github.com/WRansohoff/svd2json

Thank you for all the work that you've put into the embedded Rust ecosystem! And sorry if the syntax needs cleaning up, or if there's a better way to do this - I don't have much experience with packaging Rust crates for release.