### PR TITLE
Field arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [breaking-change] `Defaults` field renamed on `RegisterProperties`
   and added into `Peripheral` and `ClusterInfo`
+- [breaking-change] `Field` splitted on `Field` enum and `FieldInfo` struct
+  to support field arrays
 - Added `derived_from` into `Field` and `ClusterInfo`
 - Updated dependencies, use `Edition 2018`
 - Added missing `zeroToToggle`

--- a/src/svd/fieldinfo.rs
+++ b/src/svd/fieldinfo.rs
@@ -1,0 +1,210 @@
+#[cfg(feature = "unproven")]
+use std::collections::HashMap;
+
+use crate::elementext::ElementExt;
+use failure::ResultExt;
+use xmltree::Element;
+
+#[cfg(feature = "unproven")]
+use crate::encode::Encode;
+use crate::error::*;
+#[cfg(feature = "unproven")]
+use crate::new_element;
+use crate::parse;
+use crate::types::Parse;
+
+use crate::svd::{
+    access::Access, bitrange::BitRange, enumeratedvalues::EnumeratedValues,
+    modifiedwritevalues::ModifiedWriteValues, writeconstraint::WriteConstraint,
+};
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Debug, PartialEq)]
+pub struct FieldInfo {
+    pub name: String,
+    pub derived_from: Option<String>,
+    pub description: Option<String>,
+    pub bit_range: BitRange,
+    pub access: Option<Access>,
+    pub enumerated_values: Vec<EnumeratedValues>,
+    pub write_constraint: Option<WriteConstraint>,
+    pub modified_write_values: Option<ModifiedWriteValues>,
+    // Reserve the right to add more fields to this struct
+    pub(crate) _extensible: (),
+}
+
+impl Parse for FieldInfo {
+    type Object = FieldInfo;
+    type Error = SVDError;
+    fn parse(tree: &Element) -> Result<FieldInfo, SVDError> {
+        if tree.name != "field" {
+            return Err(SVDErrorKind::NotExpectedTag(tree.clone(), "field".to_string()).into());
+        }
+        let name = tree.get_child_text("name")?;
+        FieldInfo::_parse(tree, name.clone())
+            .context(SVDErrorKind::Other(format!("In field `{}`", name)))
+            .map_err(|e| e.into())
+    }
+}
+
+impl FieldInfo {
+    fn _parse(tree: &Element, name: String) -> Result<FieldInfo, SVDError> {
+        Ok(FieldInfo {
+            name,
+            derived_from: tree.attributes.get("derivedFrom").map(|s| s.to_owned()),
+            description: tree.get_child_text_opt("description")?,
+            bit_range: BitRange::parse(tree)?,
+            access: parse::optional::<Access>("access", tree)?,
+            enumerated_values: {
+                let values: Result<Vec<_>, _> = tree
+                    .children
+                    .iter()
+                    .filter(|t| t.name == "enumeratedValues")
+                    .map(EnumeratedValues::parse)
+                    .collect();
+                values?
+            },
+            write_constraint: parse::optional::<WriteConstraint>("writeConstraint", tree)?,
+            modified_write_values: parse::optional::<ModifiedWriteValues>(
+                "modifiedWriteValues",
+                tree,
+            )?,
+            _extensible: (),
+        })
+    }
+}
+
+#[cfg(feature = "unproven")]
+impl Encode for FieldInfo {
+    type Error = SVDError;
+    fn encode(&self) -> Result<Element, SVDError> {
+        let mut children = vec![new_element("name", Some(self.name.clone()))];
+
+        if let Some(description) = &self.description {
+            children.push(new_element("description", Some(description.clone())))
+        }
+
+        let mut elem = Element {
+            prefix: None,
+            namespace: None,
+            namespaces: None,
+            name: String::from("field"),
+            attributes: HashMap::new(),
+            children,
+            text: None,
+        };
+
+        if let Some(v) = &self.derived_from {
+            elem.attributes
+                .insert(String::from("derivedFrom"), format!("{}", v));
+        }
+
+        // Add bit range
+        elem.children.append(&mut self.bit_range.encode()?);
+
+        if let Some(v) = &self.access {
+            elem.children.push(v.encode()?);
+        };
+
+        let enumerated_values: Result<Vec<Element>, SVDError> =
+            self.enumerated_values.iter().map(|v| v.encode()).collect();
+        elem.children.append(&mut enumerated_values?);
+
+        if let Some(v) = &self.write_constraint {
+            elem.children.push(v.encode()?);
+        };
+
+        if let Some(v) = &self.modified_write_values {
+            elem.children.push(v.encode()?);
+        };
+
+        Ok(elem)
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "unproven")]
+mod tests {
+    use super::*;
+    use crate::run_test;
+    use crate::svd::{bitrange::BitRangeType, enumeratedvalue::EnumeratedValue};
+
+    #[test]
+    fn decode_encode() {
+        let tests = vec![
+            (
+                FieldInfo {
+                    name: String::from("MODE"),
+                    derived_from: None,
+                    description: Some(String::from("Read Mode")),
+                    bit_range: BitRange {
+                        offset: 24,
+                        width: 2,
+                        range_type: BitRangeType::OffsetWidth,
+                    },
+                    access: Some(Access::ReadWrite),
+                    enumerated_values: vec![EnumeratedValues {
+                        name: None,
+                        usage: None,
+                        derived_from: None,
+                        values: vec![EnumeratedValue {
+                            name: String::from("WS0"),
+                            description: Some(String::from(
+                                "Zero wait-states inserted in fetch or read transfers",
+                            )),
+                            value: Some(0),
+                            is_default: None,
+                            _extensible: (),
+                        }],
+                        _extensible: (),
+                    }],
+                    write_constraint: None,
+                    modified_write_values: None,
+                    _extensible: (),
+                },
+                "
+            <field>
+              <name>MODE</name>
+              <description>Read Mode</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>WS0</name>
+                  <description>Zero wait-states inserted in fetch or read transfers</description>
+                  <value>0x00000000</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            ",
+            ),
+            (
+                FieldInfo {
+                    name: String::from("MODE"),
+                    derived_from: Some(String::from("other field")),
+                    description: None,
+                    bit_range: BitRange {
+                        offset: 24,
+                        width: 2,
+                        range_type: BitRangeType::OffsetWidth,
+                    },
+                    access: None,
+                    enumerated_values: vec![],
+                    write_constraint: None,
+                    modified_write_values: None,
+                    _extensible: (),
+                },
+                "
+            <field derivedFrom=\"other field\">
+              <name>MODE</name>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            ",
+            ),
+        ];
+
+        run_test::<FieldInfo>(&tests[..]);
+    }
+}

--- a/src/svd/mod.rs
+++ b/src/svd/mod.rs
@@ -31,6 +31,9 @@ pub use self::enumeratedvalues::EnumeratedValues;
 pub mod field;
 pub use self::field::Field;
 
+pub mod fieldinfo;
+pub use self::fieldinfo::FieldInfo;
+
 pub mod registerinfo;
 pub use self::registerinfo::RegisterInfo;
 

--- a/src/svd/registerinfo.rs
+++ b/src/svd/registerinfo.rs
@@ -185,6 +185,7 @@ mod tests {
     use super::*;
     use crate::run_test;
     use crate::svd::bitrange::*;
+    use crate::svd::fieldinfo::FieldInfo;
 
     #[test]
     fn decode_encode() {
@@ -200,7 +201,7 @@ mod tests {
                 access: Some(Access::ReadWrite),
                 reset_value: Some(0x00000000),
                 reset_mask: Some(0x00000023),
-                fields: Some(vec![Field {
+                fields: Some(vec![Field::Single(FieldInfo {
                     name: String::from("WREN"),
                     derived_from: None,
                     description: Some(String::from("Enable Write/Erase Controller")),
@@ -214,7 +215,7 @@ mod tests {
                     write_constraint: None,
                     modified_write_values: None,
                     _extensible: (),
-                }]),
+                })]),
                 write_constraint: None,
                 modified_write_values: Some(ModifiedWriteValues::OneToToggle),
                 _extensible: (),


### PR DESCRIPTION
Support field arrays same way as `Register` and `Cluster`.

### Alternative:
Add `Option<DimElement>` in `Field`:
https://github.com/rust-embedded/svd/commit/c5ed1dc89b6c3b1cade1de3751f34d0b72d13101