### PR TITLE
Remove _extensible fields from structs.

### DIFF
--- a/src/svd/clusterinfo.rs
+++ b/src/svd/clusterinfo.rs
@@ -21,8 +21,6 @@ pub struct ClusterInfo {
     pub address_offset: u32,
     pub default_register_properties: RegisterProperties,
     pub children: Vec<RegisterCluster>,
-    // Reserve the right to add more fields to this struct
-    _extensible: (),
 }
 
 impl Parse for ClusterInfo {
@@ -53,7 +51,6 @@ impl ClusterInfo {
                     .collect();
                 children?
             },
-            _extensible: (),
         })
     }
 }

--- a/src/svd/cpu.rs
+++ b/src/svd/cpu.rs
@@ -22,9 +22,6 @@ pub struct Cpu {
     pub fpu_present: bool,
     pub nvic_priority_bits: u32,
     pub has_vendor_systick: bool,
-
-    // Reserve the right to add more fields to this struct
-    pub(crate) _extensible: (),
 }
 
 impl Parse for Cpu {
@@ -44,7 +41,6 @@ impl Parse for Cpu {
             fpu_present: tree.get_child_bool("fpuPresent")?,
             nvic_priority_bits: tree.get_child_u32("nvicPrioBits")?,
             has_vendor_systick: tree.get_child_bool("vendorSystickConfig")?,
-            _extensible: (),
         })
     }
 }
@@ -100,7 +96,6 @@ mod tests {
                 fpu_present: true,
                 nvic_priority_bits: 8,
                 has_vendor_systick: false,
-                _extensible: (),
             },
             "
                     <cpu>

--- a/src/svd/device.rs
+++ b/src/svd/device.rs
@@ -25,8 +25,6 @@ pub struct Device {
     pub cpu: Option<Cpu>,
     pub peripherals: Vec<Peripheral>,
     pub default_register_properties: RegisterProperties,
-    // Reserve the right to add more fields to this struct
-    _extensible: (),
 }
 
 impl Parse for Device {
@@ -53,7 +51,6 @@ impl Parse for Device {
                 ps?
             },
             default_register_properties: RegisterProperties::parse(tree)?,
-            _extensible: (),
         })
     }
 }

--- a/src/svd/dimelement.rs
+++ b/src/svd/dimelement.rs
@@ -16,8 +16,6 @@ pub struct DimElement {
     pub dim: u32,
     pub dim_increment: u32,
     pub dim_index: Option<Vec<String>>,
-    // Reserve the right to add more fields to this struct
-    _extensible: (),
 }
 
 impl Parse for DimElement {
@@ -29,7 +27,6 @@ impl Parse for DimElement {
             dim: tree.get_child_u32("dim")?,
             dim_increment: tree.get_child_u32("dimIncrement")?,
             dim_index: parse_optional::<DimIndex>("dimIndex", tree)?,
-            _extensible: (),
         })
     }
 }
@@ -69,7 +66,6 @@ mod tests {
                 dim: 100,
                 dim_increment: 4,
                 dim_index: Some(vec!["10".to_owned(), "20".to_owned()]),
-                _extensible: (),
             },
             "<dimElement>
                 <dim>100</dim>

--- a/src/svd/enumeratedvalue.rs
+++ b/src/svd/enumeratedvalue.rs
@@ -19,9 +19,8 @@ pub struct EnumeratedValue {
     pub description: Option<String>,
     pub value: Option<u32>,
     pub is_default: Option<bool>,
-    // Reserve the right to add more fields to this struct
-    pub(crate) _extensible: (),
 }
+
 impl EnumeratedValue {
     fn _parse(tree: &Element, name: String) -> Result<EnumeratedValue> {
         Ok(EnumeratedValue {
@@ -31,7 +30,6 @@ impl EnumeratedValue {
             // Suggest refactoring all parse::type methods to return result so parse::optional works.
             value: parse::optional::<u32>("value", tree)?,
             is_default: tree.get_child_bool("isDefault").ok(),
-            _extensible: (),
         })
     }
 }
@@ -101,7 +99,6 @@ mod tests {
                 )),
                 value: Some(0),
                 is_default: Some(true),
-                _extensible: (),
             },
             "
                 <enumeratedValue>

--- a/src/svd/enumeratedvalues.rs
+++ b/src/svd/enumeratedvalues.rs
@@ -20,8 +20,6 @@ pub struct EnumeratedValues {
     pub usage: Option<Usage>,
     pub derived_from: Option<String>,
     pub values: Vec<EnumeratedValue>,
-    // Reserve the right to add more fields to this struct
-    pub(crate) _extensible: (),
 }
 
 impl Parse for EnumeratedValues {
@@ -65,7 +63,6 @@ impl Parse for EnumeratedValues {
                 }
                 values
             },
-            _extensible: (),
         })
     }
 }
@@ -143,7 +140,6 @@ mod tests {
                     )),
                     value: Some(0),
                     is_default: Some(true),
-                    _extensible: (),
                 },
                 EnumeratedValue {
                     name: String::from("WS1"),
@@ -152,10 +148,8 @@ mod tests {
                     )),
                     value: Some(1),
                     is_default: None,
-                    _extensible: (),
                 },
             ],
-            _extensible: (),
         };
 
         // TODO: move to test! macro

--- a/src/svd/fieldinfo.rs
+++ b/src/svd/fieldinfo.rs
@@ -28,8 +28,6 @@ pub struct FieldInfo {
     pub enumerated_values: Vec<EnumeratedValues>,
     pub write_constraint: Option<WriteConstraint>,
     pub modified_write_values: Option<ModifiedWriteValues>,
-    // Reserve the right to add more fields to this struct
-    pub(crate) _extensible: (),
 }
 
 impl Parse for FieldInfo {
@@ -67,7 +65,6 @@ impl FieldInfo {
                 "modifiedWriteValues",
                 tree,
             )?,
-            _extensible: (),
         })
     }
 }
@@ -153,13 +150,10 @@ mod tests {
                             )),
                             value: Some(0),
                             is_default: None,
-                            _extensible: (),
                         }],
-                        _extensible: (),
                     }],
                     write_constraint: None,
                     modified_write_values: None,
-                    _extensible: (),
                 },
                 "
             <field>
@@ -192,7 +186,6 @@ mod tests {
                     enumerated_values: vec![],
                     write_constraint: None,
                     modified_write_values: None,
-                    _extensible: (),
                 },
                 "
             <field derivedFrom=\"other field\">

--- a/src/svd/peripheral.rs
+++ b/src/svd/peripheral.rs
@@ -33,8 +33,6 @@ pub struct Peripheral {
     /// `None` indicates that the `<registers>` node is not present
     pub registers: Option<Vec<RegisterCluster>>,
     pub derived_from: Option<String>,
-    // Reserve the right to add more fields to this struct
-    _extensible: (),
 }
 
 impl Parse for Peripheral {
@@ -84,7 +82,6 @@ impl Peripheral {
                 None
             },
             derived_from: tree.attributes.get("derivedFrom").map(|s| s.to_owned()),
-            _extensible: (),
         })
     }
 }

--- a/src/svd/registerinfo.rs
+++ b/src/svd/registerinfo.rs
@@ -34,8 +34,6 @@ pub struct RegisterInfo {
     pub fields: Option<Vec<Field>>,
     pub write_constraint: Option<WriteConstraint>,
     pub modified_write_values: Option<ModifiedWriteValues>,
-    // Reserve the right to add more fields to this struct
-    pub(crate) _extensible: (),
 }
 
 impl Parse for RegisterInfo {
@@ -82,7 +80,6 @@ impl RegisterInfo {
                 "modifiedWriteValues",
                 tree,
             )?,
-            _extensible: (),
         })
     }
 }
@@ -211,11 +208,9 @@ mod tests {
                     enumerated_values: Vec::new(),
                     write_constraint: None,
                     modified_write_values: None,
-                    _extensible: (),
                 })]),
                 write_constraint: None,
                 modified_write_values: Some(ModifiedWriteValues::OneToToggle),
-                _extensible: (),
             },
             "
             <register derivedFrom=\"derived from\">

--- a/src/svd/registerproperties.rs
+++ b/src/svd/registerproperties.rs
@@ -20,8 +20,6 @@ pub struct RegisterProperties {
     pub reset_value: Option<u32>,
     pub reset_mask: Option<u32>,
     pub access: Option<Access>,
-    // Reserve the right to add more fields to this struct
-    _extensible: (),
 }
 
 impl Parse for RegisterProperties {
@@ -34,7 +32,6 @@ impl Parse for RegisterProperties {
             reset_value: parse::optional::<u32>("resetValue", tree)?,
             reset_mask: parse::optional::<u32>("resetMask", tree)?,
             access: parse::optional::<Access>("access", tree)?,
-            _extensible: (),
         })
     }
 }
@@ -89,7 +86,6 @@ mod tests {
             reset_value: Some(0x11223344),
             reset_mask: Some(0x00000000),
             access: Some(Access::ReadOnly),
-            _extensible: (),
         };
 
         let tree1 = Element::parse(example.as_bytes()).unwrap();


### PR DESCRIPTION
It limits the creation of these structs from the user point of view,
adding a field to an struct is always a breaking change so it doesn't
matter really if the user can construct it or not manually. This should
enable the usage of the encode API.

This doesn't break svd2rust imho.