### PR TITLE
Fix encoding of addressUnitBits

### DIFF
--- a/src/svd/device.rs
+++ b/src/svd/device.rs
@@ -97,7 +97,7 @@ impl Encode for Device {
                 .push(new_element("description", Some(v.clone())));
         }
 
-        if let Some(v) = &self.description {
+        if let Some(v) = &self.address_unit_bits {
             elem.children
                 .push(new_element("addressUnitBits", Some(format!("{}", v))));
         }


### PR DESCRIPTION
Encoding addressUnitBits now properly encodes, instead of duplication the description field