### PR TITLE
Document and test MSRV 1.35.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ sudo: required
 rust:
   - nightly
   - stable
+  # MSRV
+  - 1.35.0
 
 env: TARGET=x86_64-unknown-linux-gnu
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ This project is developed and maintained by the [Tools team][team].
 
 ## ["Documentation"](https://docs.rs/svd-parser)
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.35.0 and up. It *might*
+compile with older versions but that may change in any new patch release.
+
 ## License
 
 Licensed under either of

--- a/src/svd/field.rs
+++ b/src/svd/field.rs
@@ -44,9 +44,9 @@ impl Parse for Field {
             if let Some(indices) = &array_info.dim_index {
                 assert_eq!(array_info.dim as usize, indices.len())
             }
-            Ok(Self::Array(info, array_info))
+            Ok(Field::Array(info, array_info))
         } else {
-            Ok(Self::Single(info))
+            Ok(Field::Single(info))
         }
     }
 }


### PR DESCRIPTION
Part of [wg/#445](https://github.com/rust-embedded/wg/issues/445).

This includes two minor changes to the code to lower the MSRV from 1.37.0 to 1.34.0.