### PR TITLE
Support `dimableIdentifierType`-style names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ xmltree = "0.8"
 anyhow = "1.0.19"
 thiserror = "1.0.5"
 rayon = "1.3.0"
+once_cell = "1.3.1"
+regex = "1"
 
 [dependencies.serde]
 version = "1.0"

--- a/src/svd/clusterinfo.rs
+++ b/src/svd/clusterinfo.rs
@@ -109,9 +109,9 @@ impl ClusterInfoBuilder {
 
 impl ClusterInfo {
     fn validate(self) -> Result<Self> {
-        check_name(&self.name, "name")?;
+        check_dimable_name(&self.name, "name")?;
         if let Some(name) = self.derived_from.as_ref() {
-            check_name(name, "derivedFrom")?;
+            check_dimable_name(name, "derivedFrom")?;
         } else {
             if self.children.is_empty() {
                 return Err(SVDError::EmptyCluster)?;

--- a/src/svd/fieldinfo.rs
+++ b/src/svd/fieldinfo.rs
@@ -127,9 +127,9 @@ impl FieldInfoBuilder {
 
 impl FieldInfo {
     fn validate(self) -> Result<Self> {
-        check_name(&self.name, "name")?;
+        check_dimable_name(&self.name, "name")?;
         if let Some(name) = self.derived_from.as_ref() {
-            check_name(name, "derivedFrom")?;
+            check_dimable_name(name, "derivedFrom")?;
         }
         for ev in &self.enumerated_values {
             ev.check_range(0..2_u32.pow(self.bit_range.width))?;

--- a/src/svd/peripheral.rs
+++ b/src/svd/peripheral.rs
@@ -159,9 +159,9 @@ impl PeripheralBuilder {
 impl Peripheral {
     fn validate(self) -> Result<Self> {
         // TODO
-        check_name(&self.name, "name")?;
+        check_dimable_name(&self.name, "name")?;
         if let Some(name) = self.derived_from.as_ref() {
-            check_name(name, "derivedFrom")?;
+            check_dimable_name(name, "derivedFrom")?;
         } else if let Some(registers) = self.registers.as_ref() {
             if registers.is_empty() {
                 return Err(SVDError::EmptyRegisters)?;

--- a/src/svd/registerinfo.rs
+++ b/src/svd/registerinfo.rs
@@ -182,15 +182,15 @@ impl RegisterInfoBuilder {
 
 impl RegisterInfo {
     fn validate(self) -> Result<Self> {
-        check_name(&self.name, "name")?;
+        check_dimable_name(&self.name, "name")?;
         if let Some(name) = self.alternate_group.as_ref() {
             check_name(name, "alternateGroup")?;
         }
         if let Some(name) = self.alternate_register.as_ref() {
-            check_name(name, "alternateRegister")?;
+            check_dimable_name(name, "alternateRegister")?;
         }
         if let Some(name) = self.derived_from.as_ref() {
-            check_name(name, "derivedFrom")?;
+            check_dimable_name(name, "derivedFrom")?;
         } else if let Some(fields) = self.fields.as_ref() {
             if fields.is_empty() {
                 return Err(SVDError::EmptyFields)?;


### PR DESCRIPTION
As of CMSIS-SVD 1.3.3 the schema allows for `dimableIdentifierType`
names in several places. This change uses the regular expressions from
the CMSIS-SVD 1.3.6 XSD for both `dimableIdentifierType` and
`identifierType`. While there is prose in ARM documentation suggesting
that all names must be valid ANSI C identifiers this is not born out by
the schema constraints.

---

This appears to have a net positive effect on the `cargo test` results:
Before: `test result: FAILED. 253 passed; 381 failed; 0 ignored; 0 measured; 0 filtered out`
After: `test result: FAILED. 424 passed; 210 failed; 0 ignored; 0 measured; 0 filtered out`