### PR TITLE
Silence unused import warning

### DIFF
--- a/generate-tests.sh
+++ b/generate-tests.sh
@@ -60,7 +60,6 @@ EOF
     done
     cat >"$tests_dir/cmsis.rs"<<EOF
 pub mod cmsis_tests;
-use cmsis_tests::*;
 EOF
 }
 


### PR DESCRIPTION
Remove the wildcard use statement inserted by generate-tests.sh that
currently generates an unused import warning.