### PR TITLE
Fix dimable_name regular expression

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -96,7 +96,7 @@ pub(crate) fn check_name(name: &str, tag: &str) -> Result<()> {
 
 pub(crate) fn check_dimable_name(name: &str, tag: &str) -> Result<()> {
     static PATTERN: Lazy<Regex> = Lazy::new(|| {
-        Regex::new("^((%s)|(%s)[_A-Za-z]{1}[_A-Za-z0-9]*)|([_A-Za-z]{1}[_A-Za-z0-9]*(\\[%s\\])?)|([_A-Za-z]{1}[_A-Za-z0-9]*(%s)?[_A-Za-z0-9]*)$").unwrap()
+        Regex::new("^(((%s)|(%s)[_A-Za-z]{1}[_A-Za-z0-9]*)|([_A-Za-z]{1}[_A-Za-z0-9]*(\\[%s\\])?)|([_A-Za-z]{1}[_A-Za-z0-9]*(%s)?[_A-Za-z0-9]*))$").unwrap()
     });
     if PATTERN.is_match(name) {
         Ok(())


### PR DESCRIPTION
The regex for dimable names wasn't anchoring the entire expression on
the start and end of lines, just the first and last optional matches.