### PR TITLE
Update MSRV to 1.36.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
   - stable
   # MSRV
-  - 1.35.0
+  - 1.38.0
 
 env: TARGET=x86_64-unknown-linux-gnu
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is developed and maintained by the [Tools team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.35.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.38.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
This accomodates crossbeam-ng's MSRV of 1.36.0, which is a dependency.