### PR TITLE
Use the stable compiler to install `cross`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
   - stable
   # MSRV
-  - 1.35.0
+  - 1.36.0
 
 env: TARGET=x86_64-unknown-linux-gnu
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is developed and maintained by the [Tools team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.35.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.36.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,7 +4,8 @@ main() {
     if [ -x "$(command -v cross)" ]; then
         cross -V
     else
-        cargo install cross
+        rustup install stable
+        cargo +stable install cross
     fi
 }
 


### PR DESCRIPTION
The `cross` tool is used during testing, but isn't a direct dependency.
Use the stable compiler when installing it instead of the active
toolchain during Travis tests to prevent having to update the MSRV to
support building `cross`.