### PR TITLE
Minor fixes for error-messages & fields with odd bitRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Peripherals are processed in parallel with `rayon`
 - Serde now skips empty tags
 - Fix: bug in `addressUnitBits`
+- Fix: panic with 32 bit wide fields that have enumerated values
+- Fix: produce error on 0-width fields
+- Fix: error instead of panic when an array/cluster name is missing the `%s` placeholder
 
 ## [v0.9.0] - 2019-11-17
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,7 +81,7 @@ pub enum NameError {
 pub enum ResetValueError {
     #[error("Reset value 0x{0:x} doesn't fit in {1} bits")]
     ValueTooLarge(u32, u32),
-    #[error("Reset value 0x{0:x} conflicts with mask '{1}'")]
+    #[error("Reset value 0x{0:x} conflicts with mask '0x{1:x}'")]
     MaskConflict(u32, u32),
     #[error("Mask value 0x{0:x} doesn't fit in {1} bits")]
     MaskTooLarge(u32, u32),

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,6 +73,8 @@ pub enum BuildError {
 pub enum NameError {
     #[error("Name `{0}` in tag `{1}` contains unexpected symbol")]
     Invalid(String, String),
+    #[error("Name `{0}` in tag `{1}` is missing a %s placeholder")]
+    MissingPlaceholder(String, String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
@@ -102,6 +104,14 @@ pub(crate) fn check_dimable_name(name: &str, tag: &str) -> Result<()> {
         Ok(())
     } else {
         Err(NameError::Invalid(name.to_string(), tag.to_string()).into())
+    }
+}
+
+pub(crate) fn check_has_placeholder(name: &str, tag: &str) -> Result<()> {
+    if name.contains("%s") {
+        Ok(())
+    } else {
+        Err(NameError::MissingPlaceholder(name.to_string(), tag.to_string()).into())
     }
 }
 

--- a/src/svd/cluster.rs
+++ b/src/svd/cluster.rs
@@ -39,10 +39,7 @@ impl Parse for Cluster {
 
         if tree.get_child("dimIncrement").is_some() {
             let array_info = DimElement::parse(tree)?;
-            if !info.name.contains("%s") {
-                // TODO: replace with real error
-                anyhow::bail!("Cluster name invalid");
-            }
+            check_has_placeholder(&info.name, "cluster")?;
 
             if let Some(indices) = &array_info.dim_index {
                 if array_info.dim as usize != indices.len() {

--- a/src/svd/field.rs
+++ b/src/svd/field.rs
@@ -40,7 +40,7 @@ impl Parse for Field {
 
         if tree.get_child("dimIncrement").is_some() {
             let array_info = DimElement::parse(tree)?;
-            assert!(info.name.contains("%s"));
+            check_has_placeholder(&info.name, "field")?;
             if let Some(indices) = &array_info.dim_index {
                 assert_eq!(array_info.dim as usize, indices.len())
             }

--- a/src/svd/fieldinfo.rs
+++ b/src/svd/fieldinfo.rs
@@ -131,8 +131,15 @@ impl FieldInfo {
         if let Some(name) = self.derived_from.as_ref() {
             check_derived_name(name, "derivedFrom")?;
         }
-        for ev in &self.enumerated_values {
-            ev.check_range(0..2_u32.pow(self.bit_range.width))?;
+
+        // If the bit_range has its maximum width, all enumerated values will of
+        // course fit in so we can skip validation.
+        //
+        // TODO: If enumerated values ever change to u64, this needs to be updated.
+        if self.bit_range.width < 32 {
+            for ev in &self.enumerated_values {
+                ev.check_range(0..2_u32.pow(self.bit_range.width))?;
+            }
         }
         Ok(self)
     }

--- a/src/svd/fieldinfo.rs
+++ b/src/svd/fieldinfo.rs
@@ -132,6 +132,10 @@ impl FieldInfo {
             check_derived_name(name, "derivedFrom")?;
         }
 
+        if self.bit_range.width == 0 {
+            anyhow::bail!("bitRange width of 0 does not make sense");
+        }
+
         // If the bit_range has its maximum width, all enumerated values will of
         // course fit in so we can skip validation.
         //

--- a/src/svd/register.rs
+++ b/src/svd/register.rs
@@ -8,6 +8,7 @@ use crate::types::Parse;
 use crate::elementext::ElementExt;
 #[cfg(feature = "unproven")]
 use crate::encode::Encode;
+use crate::error::*;
 use crate::svd::{dimelement::DimElement, registerinfo::RegisterInfo};
 use anyhow::Result;
 
@@ -40,7 +41,7 @@ impl Parse for Register {
 
         if tree.get_child("dimIncrement").is_some() {
             let array_info = DimElement::parse(tree)?;
-            assert!(info.name.contains("%s"));
+            check_has_placeholder(&info.name, "register")?;
             if let Some(indices) = &array_info.dim_index {
                 assert_eq!(array_info.dim as usize, indices.len())
             }


### PR DESCRIPTION
Hello!

I'm working with yet another broken SVD file and found a few rough edges while trying to convert it.  This PR contains 3 small improvements to error display (proper errors instead of panicking)  and a fix for fields that are 32 bits wide _and_ contain enumerated values:

### 58ddcde48052632c8fddaeb9a453a3d7a70a9016 - Add proper error for missing array/cluster placeholder
Proper error message when an array or cluster name does not contain `%s`.  Previously, this would yield a cryptic panic message without any info about the offending register/field.

### 784eeb9a10fc30acaa6d2ed0cce05ed5eb67d6c4 - ResetValueError: Print mask as hexadecimal
Minor style tweak of this error.

### 016f6ba10fbdd0c3380f87c718c1a6c348e92314 - fieldinfo: Properly deal with 32-wide fields with enumerated values
The expression `2_u32.pow(self.bit_range.width)` will overflow when the bit_range has a width of 32.  As we know that a bit_range width of 32 will mean all enumerated values must be contained in the range anyway (as long as the `EnumeratedValue.value` field is `u32`), we can skip the checks and avoid dealing with this problem.

Another solution would be to switch to `RangeInclusive<u32>` but that yields a larger diff which I wanted to avoid.

### da17b29bc4bfc2fc734d4fca023cdc7d0fc7f4f5 - fieldinfo: Disallow bitRange width == 0
A field with width 0 does not actually contain any bits so this does not make sense.  Raise an error here to prevent later code assuming a bitRange width > 0 from panicking with cryptic messages.
