### PR TITLE
ci: fix build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: check
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Due to a wrong copy-paste the `build` step of the ci was launching tests, too.
With this PR we only check if the project compiles.

## Alternative
If you like the previous approach (i.e. you want to test on nighly and 1.36.0, too) we could delete the `build` step and move the matrix in the `test` step.