### PR TITLE
Minicom XML parser/writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ derive-from = []
 strict = []
 
 [dependencies]
-xmltree = "0.8"
+minidom = "0.13.0"
 anyhow = "1.0.19"
 thiserror = "1.0.5"
 rayon = "1.5.0"

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,7 +1,7 @@
 //! Encode traits.
 //! These support encoding of SVD types to XML
 
-use xmltree::Element;
+use minidom::Element;
 
 /// Encode trait allows SVD objects to be encoded into XML elements.
 pub trait Encode {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,9 +3,9 @@
 
 pub use anyhow::{Context, Result};
 use core::u64;
+use minidom::Element;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use xmltree::Element;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@
 
 //#![deny(warnings)]
 
+pub const NS: &str = "SVD";
+
 use minidom::{Element, ElementBuilder};
 
 // ElementExt extends XML elements with useful methods
@@ -75,9 +77,9 @@ fn trim_utf8_bom(s: &str) -> &str {
 /// Helper to create new base xml elements
 pub(crate) fn new_element(name: &str, text: Option<String>) -> ElementBuilder {
     if let Some(text) = text {
-        Element::builder(name, "").append(text)
+        Element::builder(name, NS).append(text)
     } else {
-        Element::builder(name, "")
+        Element::builder(name, NS)
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,7 +1,7 @@
 //! Parse traits.
 //! These support parsing of SVD types from XML
 
-use xmltree::Element;
+use minidom::Element;
 
 /// Parse trait allows SVD objects to be parsed from XML elements.
 pub trait Parse {
@@ -20,7 +20,7 @@ pub fn optional<'a, T>(n: &str, e: &'a Element) -> anyhow::Result<Option<T::Obje
 where
     T: Parse<Error = anyhow::Error>,
 {
-    let child = match e.get_child(n) {
+    let child = match e.get_child(n, "") {
         Some(c) => c,
         None => return Ok(None),
     };

--- a/src/svd/access.rs
+++ b/src/svd/access.rs
@@ -1,4 +1,4 @@
-use xmltree::Element;
+use minidom::Element;
 
 use crate::elementext::ElementExt;
 use crate::encode::Encode;
@@ -46,7 +46,7 @@ impl Encode for Access {
             Access::WriteOnce => String::from("writeOnce"),
         };
 
-        Ok(new_element("access", Some(text)))
+        Ok(new_element("access", Some(text)).build())
     }
 }
 

--- a/src/svd/addressblock.rs
+++ b/src/svd/addressblock.rs
@@ -1,4 +1,5 @@
 use crate::elementext::ElementExt;
+use crate::NS;
 use minidom::Element;
 
 use crate::types::Parse;
@@ -32,7 +33,7 @@ impl Encode for AddressBlock {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        Ok(Element::builder("addressBlock", "")
+        Ok(Element::builder("addressBlock", NS)
             .append(new_element("offset", Some(format!("{}", self.offset))))
             .append(new_element("size", Some(format!("0x{:08.x}", self.size))))
             .append(new_element("usage", Some(self.usage.clone())))

--- a/src/svd/addressblock.rs
+++ b/src/svd/addressblock.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
 use crate::elementext::ElementExt;
-use xmltree::Element;
+use minidom::Element;
 
 use crate::types::Parse;
 
@@ -34,19 +32,11 @@ impl Encode for AddressBlock {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        Ok(Element {
-            prefix: None,
-            namespace: None,
-            namespaces: None,
-            name: String::from("addressBlock"),
-            attributes: HashMap::new(),
-            children: vec![
-                new_element("offset", Some(format!("{}", self.offset))),
-                new_element("size", Some(format!("0x{:08.x}", self.size))),
-                new_element("usage", Some(self.usage.clone())),
-            ],
-            text: None,
-        })
+        Ok(Element::builder("addressBlock", "")
+            .append(new_element("offset", Some(format!("{}", self.offset))))
+            .append(new_element("size", Some(format!("0x{:08.x}", self.size))))
+            .append(new_element("usage", Some(self.usage.clone())))
+            .build())
     }
 }
 

--- a/src/svd/bitrange.rs
+++ b/src/svd/bitrange.rs
@@ -1,3 +1,4 @@
+use crate::NS;
 use minidom::Element;
 
 use crate::error::*;
@@ -39,7 +40,7 @@ impl Parse for BitRange {
 
     fn parse(tree: &Element) -> Result<Self> {
         let (end, start, range_type): (u32, u32, BitRangeType) = if let Some(range) =
-            tree.get_child("bitRange", "")
+            tree.get_child("bitRange", NS)
         {
             let text = range.text();
             //let text = range
@@ -83,7 +84,7 @@ impl Parse for BitRange {
             )
         // TODO: Consider matching instead so we can say which of these tags are missing
         } else if let (Some(lsb), Some(msb)) =
-            (tree.get_child("lsb", ""), tree.get_child("msb", ""))
+            (tree.get_child("lsb", NS), tree.get_child("msb", NS))
         {
             (
                 // TODO: `u32::parse` should not hide it's errors
@@ -96,8 +97,8 @@ impl Parse for BitRange {
                 BitRangeType::MsbLsb,
             )
         } else if let (Some(offset), Some(width)) = (
-            tree.get_child("bitOffset", ""),
-            tree.get_child("bitWidth", ""),
+            tree.get_child("bitOffset", NS),
+            tree.get_child("bitWidth", NS),
         ) {
             // Special case because offset and width are directly provided
             // (ie. do not need to be calculated as in the final step)
@@ -148,6 +149,7 @@ impl BitRange {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::NS;
 
     #[test]
     fn decode_encode() {
@@ -158,11 +160,12 @@ mod tests {
                     width: 4,
                     range_type: BitRangeType::BitRange,
                 },
-                String::from(
-                    "
-                <fake xmlns=\"\"><bitRange>[19:16]</bitRange></fake>
+                "
+                <fake xmlns=\""
+                    .to_string()
+                    + NS
+                    + "\"><bitRange>[19:16]</bitRange></fake>
             ",
-                ),
             ),
             (
                 BitRange {
@@ -170,11 +173,12 @@ mod tests {
                     width: 4,
                     range_type: BitRangeType::OffsetWidth,
                 },
-                String::from(
-                    "
-                <fake xmlns=\"\"><bitOffset>16</bitOffset><bitWidth>4</bitWidth></fake>
+                "
+                <fake xmlns=\""
+                    .to_string()
+                    + NS
+                    + "\"><bitOffset>16</bitOffset><bitWidth>4</bitWidth></fake>
             ",
-                ),
             ),
             (
                 BitRange {
@@ -182,11 +186,12 @@ mod tests {
                     width: 4,
                     range_type: BitRangeType::MsbLsb,
                 },
-                String::from(
-                    "
-                <fake xmlns=\"\"><lsb>16</lsb><msb>19</msb></fake>
+                "
+                <fake xmlns=\""
+                    .to_string()
+                    + NS
+                    + "\"><lsb>16</lsb><msb>19</msb></fake>
             ",
-                ),
             ),
         ];
 
@@ -194,7 +199,7 @@ mod tests {
             let tree1: Element = s.parse().unwrap();
             let value = BitRange::parse(&tree1).unwrap();
             assert_eq!(value, a, "Parsing `{}` expected `{:?}`", s, a);
-            let mut tree2 = Element::builder("fake", "")
+            let mut tree2 = Element::builder("fake", NS)
                 .append_all(value.encode().unwrap())
                 .build();
             assert_eq!(tree1, tree2, "Encoding {:?} expected {}", a, s);

--- a/src/svd/cluster.rs
+++ b/src/svd/cluster.rs
@@ -1,5 +1,5 @@
 use core::ops::Deref;
-use xmltree::Element;
+use minidom::Element;
 
 use crate::types::Parse;
 
@@ -31,11 +31,11 @@ impl Parse for Cluster {
     type Error = anyhow::Error;
 
     fn parse(tree: &Element) -> Result<Self> {
-        assert_eq!(tree.name, "cluster");
+        assert_eq!(tree.name(), "cluster");
 
         let info = ClusterInfo::parse(tree)?;
 
-        if tree.get_child("dimIncrement").is_some() {
+        if tree.get_child("dimIncrement", "").is_some() {
             let array_info = DimElement::parse(tree)?;
             check_has_placeholder(&info.name, "cluster")?;
 

--- a/src/svd/cluster.rs
+++ b/src/svd/cluster.rs
@@ -1,3 +1,4 @@
+use crate::NS;
 use core::ops::Deref;
 use minidom::Element;
 
@@ -35,7 +36,7 @@ impl Parse for Cluster {
 
         let info = ClusterInfo::parse(tree)?;
 
-        if tree.get_child("dimIncrement", "").is_some() {
+        if tree.get_child("dimIncrement", NS).is_some() {
             let array_info = DimElement::parse(tree)?;
             check_has_placeholder(&info.name, "cluster")?;
 

--- a/src/svd/clusterinfo.rs
+++ b/src/svd/clusterinfo.rs
@@ -1,4 +1,5 @@
 use crate::elementext::ElementExt;
+use crate::NS;
 use minidom::Element;
 
 use crate::types::Parse;
@@ -153,7 +154,7 @@ impl Encode for ClusterInfo {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        let mut e = Element::builder("cluster", "");
+        let mut e = Element::builder("cluster", NS);
 
         if let Some(v) = &self.derived_from {
             e = e.attr(String::from("derivedFrom"), v.to_string());

--- a/src/svd/cpu.rs
+++ b/src/svd/cpu.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use xmltree::Element;
+use minidom::Element;
 
 use crate::elementext::ElementExt;
 use crate::encode::Encode;
@@ -119,7 +117,7 @@ impl Parse for Cpu {
     type Error = anyhow::Error;
 
     fn parse(tree: &Element) -> Result<Self> {
-        if tree.name != "cpu" {
+        if tree.name() != "cpu" {
             return Err(SVDError::NameMismatch(tree.clone()).into());
         }
 
@@ -139,26 +137,27 @@ impl Encode for Cpu {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        Ok(Element {
-            prefix: None,
-            namespace: None,
-            namespaces: None,
-            name: String::from("cpu"),
-            attributes: HashMap::new(),
-            children: vec![
-                new_element("name", Some(self.name.clone())),
-                new_element("revision", Some(self.revision.clone())),
-                self.endian.encode()?,
-                new_element("mpuPresent", Some(format!("{}", self.mpu_present))),
-                new_element("fpuPresent", Some(format!("{}", self.fpu_present))),
-                new_element("nvicPrioBits", Some(format!("{}", self.nvic_priority_bits))),
-                new_element(
-                    "vendorSystickConfig",
-                    Some(format!("{}", self.has_vendor_systick)),
-                ),
-            ],
-            text: None,
-        })
+        Ok(Element::builder("cpu", "")
+            .append(new_element("name", Some(self.name.clone())))
+            .append(new_element("revision", Some(self.revision.clone())))
+            .append(self.endian.encode()?)
+            .append(new_element(
+                "mpuPresent",
+                Some(format!("{}", self.mpu_present)),
+            ))
+            .append(new_element(
+                "fpuPresent",
+                Some(format!("{}", self.fpu_present)),
+            ))
+            .append(new_element(
+                "nvicPrioBits",
+                Some(format!("{}", self.nvic_priority_bits)),
+            ))
+            .append(new_element(
+                "vendorSystickConfig",
+                Some(format!("{}", self.has_vendor_systick)),
+            ))
+            .build())
     }
 }
 

--- a/src/svd/cpu.rs
+++ b/src/svd/cpu.rs
@@ -1,3 +1,4 @@
+use crate::NS;
 use minidom::Element;
 
 use crate::elementext::ElementExt;
@@ -137,7 +138,7 @@ impl Encode for Cpu {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        Ok(Element::builder("cpu", "")
+        Ok(Element::builder("cpu", NS)
             .append(new_element("name", Some(self.name.clone())))
             .append(new_element("revision", Some(self.revision.clone())))
             .append(self.endian.encode()?)

--- a/src/svd/device.rs
+++ b/src/svd/device.rs
@@ -1,4 +1,5 @@
 use crate::elementext::ElementExt;
+use crate::NS;
 use minidom::Element;
 
 use crate::parse;
@@ -178,7 +179,7 @@ impl Encode for Device {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        let mut e = Element::builder("device", "")
+        let mut e = Element::builder("device", NS)
             .attr("xmlns:xs", "http://www.w3.org/2001/XMLSchema-instance")
             .append(new_element("name", Some(self.name.clone())));
 
@@ -216,7 +217,7 @@ impl Encode for Device {
 
         let peripherals: Result<Vec<_>, _> =
             self.peripherals.iter().map(Peripheral::encode).collect();
-        e = e.append(Element::builder("peripherals", "").append_all(peripherals?));
+        e = e.append(Element::builder("peripherals", NS).append_all(peripherals?));
 
         Ok(e.build())
     }

--- a/src/svd/dimelement.rs
+++ b/src/svd/dimelement.rs
@@ -1,4 +1,4 @@
-use xmltree::Element;
+use minidom::Element;
 
 use crate::types::{parse_optional, DimIndex, Parse};
 
@@ -79,20 +79,18 @@ impl Encode for DimElement {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        let mut e = new_element("dimElement", None);
-
-        e.children
-            .push(new_element("dim", Some(format!("{}", self.dim))));
-        e.children.push(new_element(
-            "dimIncrement",
-            Some(format!("{}", self.dim_increment)),
-        ));
+        let mut e = Element::builder("dimElement", "")
+            .append(new_element("dim", Some(format!("{}", self.dim))))
+            .append(new_element(
+                "dimIncrement",
+                Some(format!("{}", self.dim_increment)),
+            ));
 
         if let Some(di) = &self.dim_index {
-            e.children.push(new_element("dimIndex", Some(di.join(","))));
+            e = e.append(new_element("dimIndex", Some(di.join(","))));
         }
 
-        Ok(e)
+        Ok(e.build())
     }
 }
 

--- a/src/svd/dimelement.rs
+++ b/src/svd/dimelement.rs
@@ -1,3 +1,4 @@
+use crate::NS;
 use minidom::Element;
 
 use crate::types::{parse_optional, DimIndex, Parse};
@@ -79,7 +80,7 @@ impl Encode for DimElement {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        let mut e = Element::builder("dimElement", "")
+        let mut e = Element::builder("dimElement", NS)
             .append(new_element("dim", Some(format!("{}", self.dim))))
             .append(new_element(
                 "dimIncrement",

--- a/src/svd/endian.rs
+++ b/src/svd/endian.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use xmltree::Element;
+use minidom::Element;
 
 use crate::elementext::ElementExt;
 use crate::encode::Encode;
@@ -45,15 +43,7 @@ impl Encode for Endian {
             Endian::Other => String::from("other"),
         };
 
-        Ok(Element {
-            prefix: None,
-            namespace: None,
-            namespaces: None,
-            name: String::from("endian"),
-            attributes: HashMap::new(),
-            children: Vec::new(),
-            text: Some(text),
-        })
+        Ok(Element::builder("endian", "").append(text).build())
     }
 }
 

--- a/src/svd/endian.rs
+++ b/src/svd/endian.rs
@@ -1,3 +1,4 @@
+use crate::NS;
 use minidom::Element;
 
 use crate::elementext::ElementExt;
@@ -43,7 +44,7 @@ impl Encode for Endian {
             Endian::Other => String::from("other"),
         };
 
-        Ok(Element::builder("endian", "").append(text).build())
+        Ok(Element::builder("endian", NS).append(text).build())
     }
 }
 

--- a/src/svd/enumeratedvalue.rs
+++ b/src/svd/enumeratedvalue.rs
@@ -1,5 +1,6 @@
 use crate::elementext::ElementExt;
 use crate::parse;
+use crate::NS;
 use minidom::Element;
 
 use crate::encode::Encode;
@@ -130,7 +131,7 @@ impl Encode for EnumeratedValue {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        let mut e = Element::builder("enumeratedValue", "")
+        let mut e = Element::builder("enumeratedValue", NS)
             .append(new_element("name", Some(self.name.clone())));
 
         if let Some(d) = &self.description {

--- a/src/svd/enumeratedvalue.rs
+++ b/src/svd/enumeratedvalue.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
-
 use crate::elementext::ElementExt;
 use crate::parse;
-use xmltree::Element;
+use minidom::Element;
 
 use crate::encode::Encode;
 use crate::error::*;
@@ -118,7 +116,7 @@ impl Parse for EnumeratedValue {
     type Error = anyhow::Error;
 
     fn parse(tree: &Element) -> Result<Self> {
-        if tree.name != "enumeratedValue" {
+        if tree.name() != "enumeratedValue" {
             return Err(
                 SVDError::NotExpectedTag(tree.clone(), "enumeratedValue".to_string()).into(),
             );
@@ -132,32 +130,23 @@ impl Encode for EnumeratedValue {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        let mut base = Element {
-            prefix: None,
-            namespace: None,
-            namespaces: None,
-            name: String::from("enumeratedValue"),
-            attributes: HashMap::new(),
-            children: vec![new_element("name", Some(self.name.clone()))],
-            text: None,
-        };
+        let mut e = Element::builder("enumeratedValue", "")
+            .append(new_element("name", Some(self.name.clone())));
 
         if let Some(d) = &self.description {
             let s = (*d).clone();
-            base.children.push(new_element("description", Some(s)));
+            e = e.append(new_element("description", Some(s)));
         };
 
         if let Some(v) = &self.value {
-            base.children
-                .push(new_element("value", Some(format!("0x{:08.x}", *v))));
+            e = e.append(new_element("value", Some(format!("0x{:08.x}", *v))));
         };
 
         if let Some(v) = &self.is_default {
-            base.children
-                .push(new_element("isDefault", Some(format!("{}", v))));
+            e = e.append(new_element("isDefault", Some(format!("{}", v))));
         };
 
-        Ok(base)
+        Ok(e.build())
     }
 }
 

--- a/src/svd/enumeratedvalues.rs
+++ b/src/svd/enumeratedvalues.rs
@@ -1,4 +1,5 @@
 use crate::elementext::ElementExt;
+use crate::NS;
 use minidom::Element;
 
 use crate::encode::Encode;
@@ -140,7 +141,7 @@ impl Encode for EnumeratedValues {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        let mut e = Element::builder("enumeratedValues", "");
+        let mut e = Element::builder("enumeratedValues", NS);
 
         if let Some(d) = &self.name {
             e = e.append(new_element("name", Some((*d).clone())));
@@ -169,9 +170,9 @@ mod tests {
 
     #[test]
     fn decode_encode() {
-        let example = String::from(
+        let example =
             "
-            <enumeratedValues xmlns=\"\" derivedFrom=\"fake_derivation\">
+            <enumeratedValues xmlns=\"".to_string() + NS + "\" derivedFrom=\"fake_derivation\">
                 <enumeratedValue>
                     <name>WS0</name>
                     <description>Zero wait-states inserted in fetch or read transfers</description>
@@ -183,8 +184,7 @@ mod tests {
                     <value>0x00000001</value>
                 </enumeratedValue>
             </enumeratedValues>
-        ",
-        );
+        ";
 
         let expected = EnumeratedValuesBuilder::default()
             .derived_from(Some("fake_derivation".to_string()))
@@ -222,7 +222,11 @@ mod tests {
     #[test]
     fn valid_children() {
         fn parse(contents: String) -> Result<EnumeratedValues> {
-            let example = String::from("<enumeratedValues>") + &contents + "</enumeratedValues>";
+            let example = "<enumeratedValues xmlns=\"".to_string()
+                + NS
+                + "\">"
+                + &contents
+                + "</enumeratedValues>";
             let tree: Element = example.parse().unwrap();
             EnumeratedValues::parse(&tree)
         }

--- a/src/svd/enumeratedvalues.rs
+++ b/src/svd/enumeratedvalues.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
 use crate::elementext::ElementExt;
-use xmltree::Element;
+use minidom::Element;
 
 use crate::encode::Encode;
 use crate::error::*;
@@ -106,23 +104,22 @@ impl Parse for EnumeratedValues {
     type Error = anyhow::Error;
 
     fn parse(tree: &Element) -> Result<Self> {
-        assert_eq!(tree.name, "enumeratedValues");
+        assert_eq!(tree.name(), "enumeratedValues");
         EnumeratedValuesBuilder::default()
             .name(tree.get_child_text_opt("name")?)
             .usage(parse::optional::<Usage>("usage", tree)?)
-            .derived_from(tree.attributes.get("derivedFrom").map(|s| s.to_owned()))
+            .derived_from(tree.attr("derivedFrom").map(|s| s.to_owned()))
             .values({
                 let values: Result<Vec<_>, _> = tree
-                    .children
-                    .iter()
+                    .children()
                     .filter(|t| {
                         ["name", "headerEnumName", "usage"]
                             .iter()
-                            .all(|s| &t.name != s)
+                            .all(|s| &t.name() != s)
                     })
                     .enumerate()
                     .map(|(e, t)| {
-                        if t.name == "enumeratedValue" {
+                        if t.name() == "enumeratedValue" {
                             EnumeratedValue::parse(t)
                                 .with_context(|| format!("Parsing enumerated value #{}", e))
                         } else {
@@ -143,34 +140,25 @@ impl Encode for EnumeratedValues {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        let mut base = Element {
-            prefix: None,
-            namespace: None,
-            namespaces: None,
-            name: String::from("enumeratedValues"),
-            attributes: HashMap::new(),
-            children: Vec::new(),
-            text: None,
-        };
+        let mut e = Element::builder("enumeratedValues", "");
 
         if let Some(d) = &self.name {
-            base.children.push(new_element("name", Some((*d).clone())));
+            e = e.append(new_element("name", Some((*d).clone())));
         };
 
         if let Some(v) = &self.usage {
-            base.children.push(v.encode()?);
+            e = e.append(v.encode()?);
         };
 
         if let Some(v) = &self.derived_from {
-            base.attributes
-                .insert(String::from("derivedFrom"), (*v).clone());
+            e = e.attr("derivedFrom", v);
         }
 
         for v in &self.values {
-            base.children.push(v.encode()?);
+            e = e.append(v.encode()?);
         }
 
-        Ok(base)
+        Ok(e.build())
     }
 }
 
@@ -183,7 +171,7 @@ mod tests {
     fn decode_encode() {
         let example = String::from(
             "
-            <enumeratedValues derivedFrom=\"fake_derivation\">
+            <enumeratedValues xmlns=\"\" derivedFrom=\"fake_derivation\">
                 <enumeratedValue>
                     <name>WS0</name>
                     <description>Zero wait-states inserted in fetch or read transfers</description>
@@ -222,7 +210,7 @@ mod tests {
             .unwrap();
 
         // TODO: move to test! macro
-        let tree1 = Element::parse(example.as_bytes()).unwrap();
+        let tree1: Element = example.parse().unwrap();
 
         let parsed = EnumeratedValues::parse(&tree1).unwrap();
         assert_eq!(parsed, expected, "Parsing tree failed");
@@ -235,7 +223,7 @@ mod tests {
     fn valid_children() {
         fn parse(contents: String) -> Result<EnumeratedValues> {
             let example = String::from("<enumeratedValues>") + &contents + "</enumeratedValues>";
-            let tree = Element::parse(example.as_bytes()).unwrap();
+            let tree: Element = example.parse().unwrap();
             EnumeratedValues::parse(&tree)
         }
 

--- a/src/svd/field.rs
+++ b/src/svd/field.rs
@@ -1,6 +1,6 @@
 use core::ops::Deref;
 
-use xmltree::Element;
+use minidom::Element;
 
 use crate::types::Parse;
 
@@ -33,11 +33,11 @@ impl Parse for Field {
     type Error = anyhow::Error;
 
     fn parse(tree: &Element) -> Result<Self> {
-        assert_eq!(tree.name, "field");
+        assert_eq!(tree.name(), "field");
 
         let info = FieldInfo::parse(tree)?;
 
-        if tree.get_child("dimIncrement").is_some() {
+        if tree.get_child("dimIncrement", "").is_some() {
             let array_info = DimElement::parse(tree)?;
             check_has_placeholder(&info.name, "field")?;
             if let Some(indices) = &array_info.dim_index {

--- a/src/svd/field.rs
+++ b/src/svd/field.rs
@@ -1,5 +1,6 @@
 use core::ops::Deref;
 
+use crate::NS;
 use minidom::Element;
 
 use crate::types::Parse;
@@ -37,7 +38,7 @@ impl Parse for Field {
 
         let info = FieldInfo::parse(tree)?;
 
-        if tree.get_child("dimIncrement", "").is_some() {
+        if tree.get_child("dimIncrement", NS).is_some() {
             let array_info = DimElement::parse(tree)?;
             check_has_placeholder(&info.name, "field")?;
             if let Some(indices) = &array_info.dim_index {

--- a/src/svd/fieldinfo.rs
+++ b/src/svd/fieldinfo.rs
@@ -1,4 +1,5 @@
 use crate::elementext::ElementExt;
+use crate::NS;
 use minidom::Element;
 
 use crate::encode::Encode;
@@ -187,7 +188,7 @@ impl Encode for FieldInfo {
 
     fn encode(&self) -> Result<Element> {
         let mut e =
-            Element::builder("field", "").append(new_element("name", Some(self.name.clone())));
+            Element::builder("field", NS).append(new_element("name", Some(self.name.clone())));
 
         if let Some(description) = &self.description {
             e = e.append(new_element("description", Some(description.clone())));

--- a/src/svd/interrupt.rs
+++ b/src/svd/interrupt.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use xmltree::Element;
+use minidom::Element;
 
 use crate::elementext::ElementExt;
 
@@ -39,7 +37,7 @@ impl Parse for Interrupt {
     type Error = anyhow::Error;
 
     fn parse(tree: &Element) -> Result<Self> {
-        if tree.name != "interrupt" {
+        if tree.name() != "interrupt" {
             return Err(SVDError::NotExpectedTag(tree.clone(), "interrupt".to_string()).into());
         }
         let name = tree.get_child_text("name")?;
@@ -51,19 +49,11 @@ impl Encode for Interrupt {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        Ok(Element {
-            prefix: None,
-            namespace: None,
-            namespaces: None,
-            name: String::from("interrupt"),
-            attributes: HashMap::new(),
-            children: vec![
-                new_element("name", Some(self.name.clone())),
-                new_element("description", self.description.clone()),
-                new_element("value", Some(format!("{}", self.value))),
-            ],
-            text: None,
-        })
+        Ok(Element::builder("interrupt", "")
+            .append(new_element("name", Some(self.name.clone())))
+            .append(new_element("description", self.description.clone()))
+            .append(new_element("value", Some(format!("{}", self.value))))
+            .build())
     }
 }
 

--- a/src/svd/interrupt.rs
+++ b/src/svd/interrupt.rs
@@ -1,3 +1,4 @@
+use crate::NS;
 use minidom::Element;
 
 use crate::elementext::ElementExt;
@@ -49,7 +50,7 @@ impl Encode for Interrupt {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        Ok(Element::builder("interrupt", "")
+        Ok(Element::builder("interrupt", NS)
             .append(new_element("name", Some(self.name.clone())))
             .append(new_element("description", self.description.clone()))
             .append(new_element("value", Some(format!("{}", self.value))))

--- a/src/svd/modifiedwritevalues.rs
+++ b/src/svd/modifiedwritevalues.rs
@@ -1,7 +1,7 @@
 use crate::elementext::ElementExt;
+use crate::new_element;
 
-use std::collections::HashMap;
-use xmltree::Element;
+use minidom::Element;
 
 use crate::types::Parse;
 
@@ -62,15 +62,7 @@ impl Encode for ModifiedWriteValues {
             Modify => "modify",
         };
 
-        Ok(Element {
-            prefix: None,
-            namespace: None,
-            namespaces: None,
-            name: String::from("modifiedWriteValues"),
-            attributes: HashMap::new(),
-            children: vec![],
-            text: Some(v.into()),
-        })
+        Ok(new_element("modifiedWriteValues", Some(v.into())).build())
     }
 }
 

--- a/src/svd/peripheral.rs
+++ b/src/svd/peripheral.rs
@@ -1,3 +1,4 @@
+use crate::NS;
 use minidom::Element;
 
 use crate::elementext::ElementExt;
@@ -203,7 +204,7 @@ impl Peripheral {
                 interrupt?
             })
             .default_register_properties(RegisterProperties::parse(tree)?)
-            .registers(if let Some(registers) = tree.get_child("registers", "") {
+            .registers(if let Some(registers) = tree.get_child("registers", NS) {
                 let rs: Result<Vec<_>, _> =
                     registers.children().map(RegisterCluster::parse).collect();
                 Some(rs?)
@@ -220,7 +221,7 @@ impl Encode for Peripheral {
 
     fn encode(&self) -> Result<Element> {
         let mut e =
-            Element::builder("peripheral", "").append(new_element("name", Some(self.name.clone())));
+            Element::builder("peripheral", NS).append(new_element("name", Some(self.name.clone())));
 
         if let Some(v) = &self.version {
             e = e.append(new_element("version", Some(v.to_string())));
@@ -252,7 +253,7 @@ impl Encode for Peripheral {
         if let Some(v) = &self.registers {
             let children: Result<Vec<_>, _> = v.iter().map(|e| e.encode()).collect();
 
-            e = e.append(Element::builder("registers", "").append_all(children?));
+            e = e.append(Element::builder("registers", NS).append_all(children?));
         };
 
         if let Some(v) = &self.derived_from {

--- a/src/svd/register.rs
+++ b/src/svd/register.rs
@@ -1,5 +1,6 @@
 use core::ops::Deref;
 
+use crate::NS;
 use minidom::Element;
 
 use crate::types::Parse;
@@ -38,7 +39,7 @@ impl Parse for Register {
 
         let info = RegisterInfo::parse(tree)?;
 
-        if tree.get_child("dimIncrement", "").is_some() {
+        if tree.get_child("dimIncrement", NS).is_some() {
             let array_info = DimElement::parse(tree)?;
             check_has_placeholder(&info.name, "register")?;
             if let Some(indices) = &array_info.dim_index {

--- a/src/svd/register.rs
+++ b/src/svd/register.rs
@@ -1,6 +1,6 @@
 use core::ops::Deref;
 
-use xmltree::Element;
+use minidom::Element;
 
 use crate::types::Parse;
 
@@ -34,11 +34,11 @@ impl Parse for Register {
     type Error = anyhow::Error;
 
     fn parse(tree: &Element) -> Result<Self> {
-        assert_eq!(tree.name, "register");
+        assert_eq!(tree.name(), "register");
 
         let info = RegisterInfo::parse(tree)?;
 
-        if tree.get_child("dimIncrement").is_some() {
+        if tree.get_child("dimIncrement", "").is_some() {
             let array_info = DimElement::parse(tree)?;
             check_has_placeholder(&info.name, "register")?;
             if let Some(indices) = &array_info.dim_index {

--- a/src/svd/registercluster.rs
+++ b/src/svd/registercluster.rs
@@ -1,4 +1,4 @@
-use xmltree::Element;
+use minidom::Element;
 
 use crate::types::Parse;
 
@@ -30,12 +30,12 @@ impl Parse for RegisterCluster {
     type Error = anyhow::Error;
 
     fn parse(tree: &Element) -> Result<Self> {
-        if tree.name == "register" {
-            Ok(RegisterCluster::Register(Register::parse(tree)?))
-        } else if tree.name == "cluster" {
-            Ok(RegisterCluster::Cluster(Cluster::parse(tree)?))
-        } else {
-            Err(SVDError::InvalidRegisterCluster(tree.clone(), tree.name.clone()).into())
+        match tree.name() {
+            "register" => Ok(RegisterCluster::Register(Register::parse(tree)?)),
+            "cluster" => Ok(RegisterCluster::Cluster(Cluster::parse(tree)?)),
+            _ => {
+                Err(SVDError::InvalidRegisterCluster(tree.clone(), tree.name().to_string()).into())
+            }
         }
     }
 }

--- a/src/svd/registerinfo.rs
+++ b/src/svd/registerinfo.rs
@@ -1,4 +1,5 @@
 use crate::elementext::ElementExt;
+use crate::NS;
 use minidom::Element;
 
 use crate::encode::Encode;
@@ -218,7 +219,7 @@ impl RegisterInfo {
             .address_offset(tree.get_child_u32("addressOffset")?)
             .properties(RegisterProperties::parse(tree)?)
             .fields({
-                if let Some(fields) = tree.get_child("fields", "") {
+                if let Some(fields) = tree.get_child("fields", NS) {
                     let fs: Result<Vec<_>, _> = fields
                         .children()
                         .enumerate()
@@ -244,7 +245,7 @@ impl Encode for RegisterInfo {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        let mut e = Element::builder("register", "")
+        let mut e = Element::builder("register", NS)
             .append(new_element("name", Some(self.name.clone())))
             .append(new_element(
                 "addressOffset",
@@ -288,7 +289,7 @@ impl Encode for RegisterInfo {
                 .map(Field::encode)
                 .collect::<Result<Vec<Element>>>()?;
             if !children.is_empty() {
-                let fields = Element::builder("fields", "").append_all(children);
+                let fields = Element::builder("fields", NS).append_all(children);
                 e = e.append(fields);
             }
         };

--- a/src/svd/registerproperties.rs
+++ b/src/svd/registerproperties.rs
@@ -1,4 +1,4 @@
-use xmltree::Element;
+use minidom::Element;
 
 use crate::encode::Encode;
 use crate::encode::EncodeChildren;
@@ -61,15 +61,15 @@ impl EncodeChildren for RegisterProperties {
         let mut children = Vec::new();
 
         if let Some(v) = &self.size {
-            children.push(new_element("size", Some(format!("0x{:08.x}", v))));
+            children.push(new_element("size", Some(format!("0x{:08.x}", v))).build());
         };
 
         if let Some(v) = &self.reset_value {
-            children.push(new_element("resetValue", Some(format!("0x{:08.x}", v))));
+            children.push(new_element("resetValue", Some(format!("0x{:08.x}", v))).build());
         };
 
         if let Some(v) = &self.reset_mask {
-            children.push(new_element("resetMask", Some(format!("0x{:08.x}", v))));
+            children.push(new_element("resetMask", Some(format!("0x{:08.x}", v))).build());
         };
 
         if let Some(v) = &self.access {
@@ -103,13 +103,14 @@ mod tests {
         expected.reset_mask = Some(0xffffffff);
         expected.access = Some(Access::ReadOnly);
 
-        let tree1 = Element::parse(example.as_bytes()).unwrap();
+        let tree1: Element = example.parse().unwrap();
 
         let parsed = RegisterProperties::parse(&tree1).unwrap();
         assert_eq!(parsed, expected, "Parsing tree failed");
 
-        let mut tree2 = new_element("mock", None);
-        tree2.children = parsed.encode().unwrap();
+        let mut tree2 = Element::builder("mock", "")
+            .append_all(parsed.encode().unwrap())
+            .build();
         assert_eq!(tree1, tree2, "Encoding value failed");
     }
 }

--- a/src/svd/registerproperties.rs
+++ b/src/svd/registerproperties.rs
@@ -83,19 +83,21 @@ impl EncodeChildren for RegisterProperties {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::NS;
 
     #[test]
     fn decode_encode() {
-        let example = String::from(
-            "
-            <mock>
+        let example = "
+            <mock xmlns=\""
+            .to_string()
+            + NS
+            + "\">
                 <size>0xaabbccdd</size>
                 <resetValue>0x11223344</resetValue>
                 <resetMask>0xffffffff</resetMask>
                 <access>read-only</access>
             </mock>
-        ",
-        );
+        ";
 
         let mut expected = RegisterProperties::default();
         expected.size = Some(0xaabbccdd);
@@ -108,7 +110,7 @@ mod tests {
         let parsed = RegisterProperties::parse(&tree1).unwrap();
         assert_eq!(parsed, expected, "Parsing tree failed");
 
-        let mut tree2 = Element::builder("mock", "")
+        let mut tree2 = Element::builder("mock", NS)
             .append_all(parsed.encode().unwrap())
             .build();
         assert_eq!(tree1, tree2, "Encoding value failed");

--- a/src/svd/usage.rs
+++ b/src/svd/usage.rs
@@ -1,4 +1,5 @@
 use crate::elementext::ElementExt;
+use crate::NS;
 use minidom::Element;
 
 use crate::encode::Encode;
@@ -39,7 +40,7 @@ impl Encode for Usage {
             Usage::ReadWrite => String::from("read-write"),
         };
 
-        Ok(Element::builder("usage", "").append(text).build())
+        Ok(Element::builder("usage", NS).append(text).build())
     }
 }
 

--- a/src/svd/usage.rs
+++ b/src/svd/usage.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
 use crate::elementext::ElementExt;
-use xmltree::Element;
+use minidom::Element;
 
 use crate::encode::Encode;
 use crate::error::*;
@@ -41,15 +39,7 @@ impl Encode for Usage {
             Usage::ReadWrite => String::from("read-write"),
         };
 
-        Ok(Element {
-            prefix: None,
-            namespace: None,
-            namespaces: None,
-            name: String::from("usage"),
-            attributes: HashMap::new(),
-            children: Vec::new(),
-            text: Some(text),
-        })
+        Ok(Element::builder("usage", "").append(text).build())
     }
 }
 

--- a/src/svd/writeconstraint.rs
+++ b/src/svd/writeconstraint.rs
@@ -1,4 +1,5 @@
 use crate::elementext::ElementExt;
+use crate::NS;
 use minidom::Element;
 
 use crate::encode::Encode;
@@ -62,7 +63,7 @@ impl Encode for WriteConstraint {
             WriteConstraint::Range(v) => v.encode()?,
         };
 
-        Ok(Element::builder("writeConstraint", "").append(v).build())
+        Ok(Element::builder("writeConstraint", NS).append(v).build())
     }
 }
 
@@ -82,7 +83,7 @@ impl Encode for WriteConstraintRange {
     type Error = anyhow::Error;
 
     fn encode(&self) -> Result<Element> {
-        Ok(Element::builder("range", "")
+        Ok(Element::builder("range", NS)
             .append(new_element("minimum", Some(format!("0x{:08.x}", self.min))))
             .append(new_element("maximum", Some(format!("0x{:08.x}", self.max))))
             .build())

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Shared primitive types for use in SVD objects.
 
-use xmltree::Element;
+use minidom::Element;
 
 pub use crate::encode::Encode;
 pub use crate::parse::optional as parse_optional;
@@ -86,7 +86,7 @@ impl Parse for BoolParse {
     type Error = anyhow::Error;
 
     fn parse(tree: &Element) -> Result<bool> {
-        let text = unwrap!(tree.text.as_ref());
+        let text = tree.text();
         Ok(match text.as_ref() {
             "0" => false,
             "1" => true,


### PR DESCRIPTION
I tried to replace `xmltree` with `minicom`, which uses `quick-xml`.
But I have problem. Since `0.13` version it requires `xmlns` namespace to be used to build each `Element`.

In other hand compiling with `0.12` version fails with:
```
error[E0277]: `Rc<minidom::namespace_set::NamespaceSet>` cannot be sent between threads safely
  --> src/types.rs:96:93
   |
96 |                     return Err(SVDError::InvalidBooleanValue(tree.clone(), text.clone(), e).into())
   |                                                                                             ^^^^ `Rc<minidom::namespace_set::NamespaceSet>` cannot be sent between threads safely
```

I like also `roxmltree` crate for high-level interaction with xml. But it can be used for parse only.

#109 