### PR TITLE
WIP: Fail if a register array is derived

### DIFF
--- a/svd-parser/src/lib.rs
+++ b/svd-parser/src/lib.rs
@@ -190,7 +190,7 @@ pub enum SVDError {
     UnknownWriteConstraint,
     #[error("Multiple wc found")]
     MoreThanOneWriteConstraint,
-    #[error("No support for registers arrays which are derived")]
+    #[error("No support for register arrays which are derived")]
     DerivedRegisterArray,
     #[error("Unknown usage variant")]
     UnknownUsageVariant,

--- a/svd-parser/src/lib.rs
+++ b/svd-parser/src/lib.rs
@@ -190,8 +190,8 @@ pub enum SVDError {
     UnknownWriteConstraint,
     #[error("Multiple wc found")]
     MoreThanOneWriteConstraint,
-    #[error("No support for registers with arrays which are derived")]
-    DerivedRegisterWithArray,
+    #[error("No support for registers arrays which are derived")]
+    DerivedRegisterArray,
     #[error("Unknown usage variant")]
     UnknownUsageVariant,
     #[error("Unknown usage variant for addressBlock")]

--- a/svd-parser/src/lib.rs
+++ b/svd-parser/src/lib.rs
@@ -190,6 +190,8 @@ pub enum SVDError {
     UnknownWriteConstraint,
     #[error("Multiple wc found")]
     MoreThanOneWriteConstraint,
+    #[error("No support for registers with arrays which are derived")]
+    DerivedRegisterWithArray,
     #[error("Unknown usage variant")]
     UnknownUsageVariant,
     #[error("Unknown usage variant for addressBlock")]

--- a/svd-parser/src/register.rs
+++ b/svd-parser/src/register.rs
@@ -16,6 +16,12 @@ impl Parse for Register {
 
         if tree.get_child("dimIncrement").is_some() {
             let array_info = DimElement::parse(tree, config)?;
+            if info.derived_from.is_some() {
+                return Err(SVDErrorAt {
+                    error: SVDError::DerivedRegisterWithArray,
+                    id: tree.id()
+                })
+            }
             check_has_placeholder(&info.name, "register").map_err(|e| e.at(tree.id()))?;
             if let Some(indexes) = &array_info.dim_index {
                 if array_info.dim as usize != indexes.len() {

--- a/svd-parser/src/register.rs
+++ b/svd-parser/src/register.rs
@@ -18,7 +18,7 @@ impl Parse for Register {
             let array_info = DimElement::parse(tree, config)?;
             if info.derived_from.is_some() {
                 return Err(SVDErrorAt {
-                    error: SVDError::DerivedRegisterWithArray,
+                    error: SVDError::DerivedRegisterArray,
                     id: tree.id()
                 })
             }


### PR DESCRIPTION
I don't think this feature is implemented yet. I'm not sure how easy or difficult it is to be implemented, but this PR improved the error from something like 

```sh
[ERROR svd2rust] expected `,`
```

to something like

```sh
[ERROR svd2rust] In device `va108xx`
    
    Caused by:
        0: In peripheral `IRQSEL`
        1: Parsing register `PORTA[%s]` at 503:9
        2: No support for registers arrays which are derived
```

when parsing register blocks like this

```xml
        <register derivedFrom="INT_RAM_SBE">
          <dim>32</dim>
          <dimIncrement>4</dimIncrement>
          <name>PORTB[%s]</name>
          <description>PORTB Interrupt Redirect Selection</description>
          <addressOffset>0x080</addressOffset>
        </register>
```

If implementing the support for the  `derivedFrom` attribute on register arrays is not difficult (or I am indeed not doing something wrong) this PR could of course also be skipped. I also have not tested it with any other files other than the one I am trying to parse here: https://github.com/robamu/va108xx-rs