### PR TITLE
fix: replace %S to %s in encode's change_case

### DIFF
--- a/svd-encoder/src/config.rs
+++ b/svd-encoder/src/config.rs
@@ -51,12 +51,14 @@ pub fn change_case(s: &str, case: Option<IdentifierFormat>) -> String {
                 Boundary::Acronym,
             ];
 
-            s.with_boundaries(&boundary).to_case(match case {
-                IdentifierFormat::Camel => Case::Camel,
-                IdentifierFormat::Pascal => Case::Pascal,
-                IdentifierFormat::Snake => Case::Snake,
-                IdentifierFormat::Constant => Case::UpperSnake,
-            })
+            s.with_boundaries(&boundary)
+                .to_case(match case {
+                    IdentifierFormat::Camel => Case::Camel,
+                    IdentifierFormat::Pascal => Case::Pascal,
+                    IdentifierFormat::Snake => Case::Snake,
+                    IdentifierFormat::Constant => Case::UpperSnake,
+                })
+                .replace("%S", "%s")
         }
     }
 }


### PR DESCRIPTION
Previous in `svd-encoder::config::change_case`, `%s` will be changed to `%S` when the case is `Constant`. This commit fix this via `replace("%S", "%s")`.