### PR TITLE
svd-encoder: fix device node 'headerDefinitionsPrefix'

### DIFF
--- a/svd-encoder/src/device.rs
+++ b/svd-encoder/src/device.rs
@@ -41,7 +41,7 @@ impl Encode for Device {
 
         if let Some(v) = &self.header_definitions_prefix {
             elem.children
-                .push(new_node("header_definitions_prefix", v.clone()));
+                .push(new_node("headerDefinitionsPrefix", v.clone()));
         }
 
         elem.children.push(new_node(

--- a/svd-parser/src/expand.rs
+++ b/svd-parser/src/expand.rs
@@ -259,7 +259,7 @@ impl<'a> Index<'a> {
     fn add_field(&mut self, path: &RegisterPath, f: &'a Field) {
         if let Field::Array(info, dim) = f {
             for name in names(info, dim) {
-                let fpath = path.new_field(&name);
+                let fpath = path.new_field(name);
                 for evs in &f.enumerated_values {
                     if let Some(name) = evs.name.as_ref() {
                         self.evs.insert(fpath.new_enum(name), evs);

--- a/svd-rs/src/registercluster.rs
+++ b/svd-rs/src/registercluster.rs
@@ -7,6 +7,7 @@ use super::{Cluster, Register};
     serde(rename_all = "lowercase")
 )]
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum RegisterCluster {
     /// Register
     Register(Register),


### PR DESCRIPTION
This fixes a typo when encoding the `headerDefinitionsPrefix` node in a device, which otherwise results in an invalid XML generated by `svdtools patch`:
```
$ xmllint --schema svd/cmsis-svd.xsd --noout  svd/lpc1342.svd.patched

svd/lpc1342.svd.patched:15: element header_definitions_prefix:
 Schemas validity error : Element 'header_definitions_prefix':
 This element is not expected.
 Expected is one of ( headerSystemFilename, headerDefinitionsPrefix, addressUnitBits )
```

Ref: https://github.com/lpc-rs/lpc-pac/pull/77