### PR TITLE
M318 and M351 checks

### DIFF
--- a/svd-encoder/src/peripheral.rs
+++ b/svd-encoder/src/peripheral.rs
@@ -36,7 +36,9 @@ impl Encode for PeripheralInfo {
         ));
 
         if let Some(v) = &self.display_name {
-            elem.children.push(new_node("displayName", v.to_string()));
+            if v.ne(&self.name) {
+                elem.children.push(new_node("displayName", v.to_string()));
+            }
         }
 
         if let Some(v) = &self.version {
@@ -44,18 +46,24 @@ impl Encode for PeripheralInfo {
         }
 
         if let Some(v) = &self.description {
-            elem.children.push(new_node("description", v.to_string()));
+            if v.ne(&self.name) {
+                elem.children.push(new_node("description", v.to_string()));
+            }
         }
 
         if let Some(v) = &self.alternate_peripheral {
-            elem.children.push(new_node(
-                "alternatePeripheral",
-                change_case(v, config.peripheral_name),
-            ));
+            if v.ne(&self.name) {
+                elem.children.push(new_node(
+                    "alternatePeripheral",
+                    change_case(v, config.peripheral_name),
+                ));
+            }
         }
 
         if let Some(v) = &self.group_name {
-            elem.children.push(new_node("groupName", v.to_string()));
+            if v.ne(&self.name) {
+                elem.children.push(new_node("groupName", v.to_string()));
+            }
         }
 
         if let Some(v) = &self.prepend_to_name {
@@ -73,10 +81,12 @@ impl Encode for PeripheralInfo {
         }
 
         if let Some(v) = &self.header_struct_name {
-            elem.children.push(new_node(
-                "headerStructName",
-                change_case(v, config.peripheral_name),
-            ));
+            if v.ne(&self.name) {
+                elem.children.push(new_node(
+                    "headerStructName",
+                    change_case(v, config.peripheral_name),
+                ));
+            }
         }
 
         elem.children.push(new_node(

--- a/svd-encoder/src/register.rs
+++ b/svd-encoder/src/register.rs
@@ -36,11 +36,15 @@ impl Encode for RegisterInfo {
         ));
 
         if let Some(v) = &self.display_name {
-            elem.children.push(new_node("displayName", v.clone()));
+            if v.ne(&self.name) {
+                elem.children.push(new_node("displayName", v.clone()));
+            }
         }
 
         if let Some(v) = &self.description {
-            elem.children.push(new_node("description", v.clone()));
+            if v.ne(&self.name) {
+                elem.children.push(new_node("description", v.clone()));
+            }
         }
 
         if let Some(v) = &self.alternate_group {
@@ -49,10 +53,12 @@ impl Encode for RegisterInfo {
         }
 
         if let Some(v) = &self.alternate_register {
-            elem.children.push(new_node(
-                "alternateRegister",
-                change_case(v, config.register_name),
-            ));
+            if v.ne(&self.name) {
+                elem.children.push(new_node(
+                    "alternateRegister",
+                    change_case(v, config.register_name),
+                ));
+            }
         }
 
         elem.children.push(new_node(


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->

Message Number | Type | Message Text 
-- | -- | -- 
M318 | WARNING | 'LEVEL' 'NAME' <'TAG'> is equal to \<name>
M351 | WARNING | Peripheral 'TYPE' 'NAME' is equal to Peripheral name.

<!--EndFragment-->
</body>
</html>

Doesn't add if it's equal to name:
Peripheral:
- displayName
- description
- alternatePeripheral
- groupName
- headerStructName
Register:
- displayName
- description
- alternateRegister

I can't say that I'm happy with this method. This may be unexpected for the user.
But this is a very simple way to remove `displayName` duplicate `name` in my case. Patching this manually seems terrible.