### PR TITLE
release 0.14.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - rust: nightly
             experimental: true
           # MSRV
-          - rust: 1.58.0
+          - rust: 1.60.0
             name: "MSRV"
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - rust: nightly
             experimental: true
           # MSRV
-          - rust: 1.60.0
+          - rust: 1.61.0
             name: "MSRV"
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It consists of:
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.58.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.61.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/svd-encoder/Cargo.toml
+++ b/svd-encoder/Cargo.toml
@@ -7,13 +7,13 @@ license = "MIT OR Apache-2.0"
 name = "svd-encoder"
 repository = "https://github.com/rust-embedded/svd"
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.61.0"
 version = "0.14.4"
 readme = "README.md"
 
 [dependencies]
 convert_case = "0.6.0"
-svd-rs = { version = "0.14.4", path = "../svd-rs" }
+svd-rs = { version = "0.14.7", path = "../svd-rs" }
 thiserror = "1.0.31"
 
 [dependencies.xmltree]

--- a/svd-encoder/README.md
+++ b/svd-encoder/README.md
@@ -13,7 +13,7 @@ This project is developed and maintained by the [Tools team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.58.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.61.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/svd-parser/CHANGELOG.md
+++ b/svd-parser/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.14.5] - 2024-01-03
 
-- Bump MSRV to 1.60.0
+- Bump MSRV to 1.61.0
 - Bump svd-rs to 0.14.7, roxmltree to 0.19
 
 ## [v0.14.4] - 2023-11-15

--- a/svd-parser/CHANGELOG.md
+++ b/svd-parser/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [v0.14.5] - 2024-01-03
+
+- Bump MSRV to 1.60.0
+- Bump svd-rs to 0.14.7, roxmltree to 0.19
+
 ## [v0.14.4] - 2023-11-15
 
 - Bump svd-rs dependency to 0.14.4 or higher.
@@ -63,7 +68,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Previous versions in common [changelog](../CHANGELOG.md).
 
-[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-parser-v0.14.4...HEAD
+[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.7...HEAD
+[v0.14.5]: https://github.com/rust-embedded/svd/compare/svd-parser-v0.14.4...svd-rs-v0.14.7
 [v0.14.4]: https://github.com/rust-embedded/svd/compare/svd-parser-v0.14.3...svd-parser-v0.14.4
 [v0.14.3]: https://github.com/rust-embedded/svd/compare/svd-parser-v0.14.2...svd-parser-v0.14.3
 [v0.14.2]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.2...svd-parser-v0.14.2

--- a/svd-parser/Cargo.toml
+++ b/svd-parser/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "svd-parser"
 repository = "https://github.com/rust-embedded/svd"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 version = "0.14.5"
 readme = "README.md"
 

--- a/svd-parser/Cargo.toml
+++ b/svd-parser/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT OR Apache-2.0"
 name = "svd-parser"
 repository = "https://github.com/rust-embedded/svd"
 edition = "2021"
-rust-version = "1.58.0"
-version = "0.14.4"
+rust-version = "1.60.0"
+version = "0.14.5"
 readme = "README.md"
 
 [features]
@@ -19,15 +19,15 @@ derive-from = ["svd-rs/derive-from"]
 expand = ["derive-from"]
 
 [dependencies]
-svd-rs = { version = "0.14.4", path = "../svd-rs" }
-roxmltree = "0.18"
+svd-rs = { version = "0.14.7", path = "../svd-rs" }
+roxmltree = "0.19"
 anyhow = "1.0.58"
 thiserror = "1.0.31"
 
 [dev-dependencies]
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.8.26"
-svd-rs = { version = "0.14.4", path = "../svd-rs", features = ["serde"] }
+svd-rs = { version = "0.14.7", path = "../svd-rs", features = ["serde"] }
 
 [[example]]
 name = "svd2json"

--- a/svd-parser/README.md
+++ b/svd-parser/README.md
@@ -13,7 +13,7 @@ This project is developed and maintained by the [Tools team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.58.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.61.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/svd-parser/src/expand.rs
+++ b/svd-parser/src/expand.rs
@@ -128,7 +128,10 @@ impl FieldPath {
         let name = v.pop().unwrap();
         let register = if !v.is_empty() {
             let (block, rname) = RegisterPath::parse_vec(v);
-            Some(RegisterPath::new(block.unwrap(), rname))
+            Some(RegisterPath::new(
+                block.expect("Full qualifying field path is expected"),
+                rname,
+            ))
         } else {
             None
         };

--- a/svd-rs/CHANGELOG.md
+++ b/svd-rs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [v0.14.7] - 2024-01-03
+
 - use close range in `EnumeratedValue` error message
 
 ## [v0.14.6] - 2023-11-29
@@ -105,7 +107,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Previous versions in common [changelog](../CHANGELOG.md).
 
-[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.6...HEAD
+[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.7...HEAD
+[v0.14.7]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.6...svd-rs-v0.14.7
 [v0.14.6]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.5...svd-rs-v0.14.6
 [v0.14.5]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.4...svd-rs-v0.14.5
 [v0.14.4]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.3...svd-rs-v0.14.4

--- a/svd-rs/CHANGELOG.md
+++ b/svd-rs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.14.7] - 2024-01-03
 
+- Bump MSRV to 1.61.0
 - use close range in `EnumeratedValue` error message
 
 ## [v0.14.6] - 2023-11-29

--- a/svd-rs/Cargo.toml
+++ b/svd-rs/Cargo.toml
@@ -10,7 +10,7 @@ name = "svd-rs"
 repository = "https://github.com/rust-embedded/svd"
 edition = "2021"
 rust-version = "1.58.0"
-version = "0.14.6"
+version = "0.14.7"
 readme = "README.md"
 
 [features]
@@ -20,10 +20,10 @@ derive-from = []
 thiserror = "1.0.31"
 
 [dependencies.regex]
-version = "1"
+version = "1.9"
 
 [dependencies.once_cell]
-version = "1.17.1"
+version = "1.17.2"
 
 [dependencies.serde]
 version = "1.0"

--- a/svd-rs/Cargo.toml
+++ b/svd-rs/Cargo.toml
@@ -20,7 +20,7 @@ derive-from = []
 thiserror = "1.0.31"
 
 [dependencies.regex]
-version = "1.9"
+version = "=1.9.6"
 
 [dependencies.once_cell]
 version = "1.17.2"

--- a/svd-rs/Cargo.toml
+++ b/svd-rs/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "svd-rs"
 repository = "https://github.com/rust-embedded/svd"
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.61.0"
 version = "0.14.7"
 readme = "README.md"
 

--- a/svd-rs/README.md
+++ b/svd-rs/README.md
@@ -13,7 +13,7 @@ This project is developed and maintained by the [Tools team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.60.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.61.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/svd-rs/README.md
+++ b/svd-rs/README.md
@@ -13,7 +13,7 @@ This project is developed and maintained by the [Tools team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.58.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.60.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,6 +11,6 @@ publish = false
 svd-rs = { path = "../svd-rs"}
 svd-parser = { path = "../svd-parser"}
 svd-encoder = { path = "../svd-encoder"}
-roxmltree = "0.18"
+roxmltree = "0.19"
 xmltree = "0.10.3"
 anyhow = "1.0.45"


### PR DESCRIPTION
`regex` 1.10 requires rust 1.65. So I've fixed it to `1.9`.
cc @Emilgardis 