### PR TITLE
Fix dependency of svd-parser on svd-rs

### DIFF
--- a/svd-parser/CHANGELOG.md
+++ b/svd-parser/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Bump svd-rs to 0.14.9
+
 ## [v0.14.6] - 2024-08-20
 
 - Adapt the `riscv` element to handle `riscv::Exception`.

--- a/svd-parser/Cargo.toml
+++ b/svd-parser/Cargo.toml
@@ -20,7 +20,7 @@ expand = ["derive-from"]
 unstable-riscv = ["svd-rs/unstable-riscv"]
 
 [dependencies]
-svd-rs = { version = "0.14.7", path = "../svd-rs" }
+svd-rs = { version = "0.14.9", path = "../svd-rs" }
 roxmltree = "0.20"
 anyhow = "1.0.58"
 thiserror = "1.0.31"


### PR DESCRIPTION
Version 0.14.6 of the `svd-parser`uses `Datatype` from the `svd-rs`crate, which was added in version 0.14.9.

This unfortunately means that the released version of `svd-parser` is broken, if it ends up being used in a project where `svd-rs`is used in a version earlier than 0.14.9.

See <https://github.com/probe-rs/probe-rs/pull/2814> for the compilation error.