### PR TITLE
adding children to cluster modify

### DIFF
--- a/svd-rs/src/cluster.rs
+++ b/svd-rs/src/cluster.rs
@@ -240,7 +240,7 @@ impl ClusterInfo {
             self.default_register_properties
                 .modify_from(builder.default_register_properties, lvl)?;
             if let Some(children) = builder.children {
-                self.children = children;
+                self.children.extend(children);
             }
         }
         self.validate(lvl)


### PR DESCRIPTION
when using cluster modify, it only adds the incoming children, and deletes the existing children

this just extends the existing children array with the incoming children