### PR TITLE
Prepare release of svd-parser 0.16.7

### DIFF
--- a/svd-parser/CHANGELOG.md
+++ b/svd-parser/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [v0.14.7] - 2024-10-03
 
 - Bump svd-rs to 0.14.9
 

--- a/svd-parser/Cargo.toml
+++ b/svd-parser/Cargo.toml
@@ -11,7 +11,7 @@ name = "svd-parser"
 repository = "https://github.com/rust-embedded/svd"
 edition = "2021"
 rust-version = "1.65.0"
-version = "0.14.6"
+version = "0.14.7"
 readme = "README.md"
 
 [features]


### PR DESCRIPTION
Would it be possible to get a release with the fix from https://github.com/rust-embedded/svd/pull/273?

Thanks!