### PR TITLE
Add missing `DeriveFrom` entry for `address_block`

### DIFF
--- a/svd-rs/CHANGELOG.md
+++ b/svd-rs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add missing entry for `address_block` in `DeriveFrom` impl
+
 ## [v0.14.11] - 2025-02-10
 
 - Partially revert #283. Check name on "%s" when derive array

--- a/svd-rs/src/derive_from.rs
+++ b/svd-rs/src/derive_from.rs
@@ -56,6 +56,9 @@ impl DeriveFrom for PeripheralInfo {
             .default_register_properties
             .derive_from(&other.default_register_properties);
         derived.registers = derived.registers.or_else(|| other.registers.clone());
+        derived.address_block = derived
+            .address_block
+            .or_else(|| other.address_block.clone());
         if derived.interrupt.is_empty() {
             derived.interrupt = other.interrupt.clone();
         }


### PR DESCRIPTION
Fixes #288

I didn't look much into it, but i'm pretty sure we only copy the address blocks if the entry is absent in the derived info.