### PR TITLE
Handle overrides in element group derivation

### DIFF
--- a/svd-rs/CHANGELOG.md
+++ b/svd-rs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Bump MSRV to 1.84.0
 - Set `resolver = "3"`, which implies `resolver.incompatible-rust-versions = "fallback"`
+- Allow overriding `dimElementGroup` fields when deriving.
 
 ## [v0.14.12] - 2025-03-11
 


### PR DESCRIPTION
I have an SVD file with two instances of a peripheral. The second peripheral contains the same registers, but instead of 128 it only has 64. The SVD file uses `derivedFrom` in the second peripheral to inherit these registers but overrides the `<dim>` element. To my surprise, `svd2rust` generated arrays with the same number of elements for both instances.
Well, after following the trail I ended up here and the reason wasn't hard to find.


I saw #283 and the follow up #286, but there's little to no reasoning attached to these PRs.

Looking at the spec [here](https://open-cmsis-pack.github.io/svd-spec/main/elem_registers.html#elem_register) I really don't see a reason why the fields from `dimElementGroup` shouldn't also be overridden.
The `derivedFrom` description reads

> Specify the register name from which to inherit data. Elements specified subsequently override inherited values. 

I can't see a statement about the `dimElementGroup` elements somehow being exempt.