### PR TITLE
Change parsing of the CPU block to have optional mpuPresent and

### DIFF
--- a/svd-parser/src/cpu.rs
+++ b/svd-parser/src/cpu.rs
@@ -20,12 +20,22 @@ impl Parse for Cpu {
             _ => false,
         };
 
+        let has_mpu_present = match tree.get_child_bool("mpuPresent") {
+            Ok(v) => v,
+            _ => false,
+        };
+
+        let has_fpu_present = match tree.get_child_bool("fpuPresent") {
+            Ok(v) => v,
+            _ => false,
+        };
+
         Cpu::builder()
             .name(tree.get_child_text("name")?)
             .revision(tree.get_child_text("revision")?)
             .endian(Endian::parse(&tree.get_child_elem("endian")?, config)?)
-            .mpu_present(tree.get_child_bool("mpuPresent")?)
-            .fpu_present(tree.get_child_bool("fpuPresent")?)
+            .mpu_present(has_mpu_present)
+            .fpu_present(has_fpu_present)
             .fpu_double_precision(optional::<BoolParse>("fpuDP", tree, &())?)
             .dsp_present(optional::<BoolParse>("dspPresent", tree, &())?)
             .icache_present(optional::<BoolParse>("icachePresent", tree, &())?)

--- a/tests/src/cpu.rs
+++ b/tests/src/cpu.rs
@@ -16,7 +16,7 @@ fn decode_encode() {
             .unwrap(),
         "
                 <cpu>
-                    <name>EFM32JG12B500F512GM48</name>  
+                    <name>EFM32JG12B500F512GM48</name>
                     <revision>5.1.1</revision>
                     <endian>little</endian>
                     <mpuPresent>true</mpuPresent>
@@ -27,7 +27,7 @@ fn decode_encode() {
             ",
         "
                 <cpu>
-                    <name>EFM32JG12B500F512GM48</name>  
+                    <name>EFM32JG12B500F512GM48</name>
                     <revision>5.1.1</revision>
                     <endian>little</endian>
                     <mpuPresent>true</mpuPresent>


### PR DESCRIPTION
fpuPresent elements

Per the SVD schema; these 2 elements are actually optional. However the documentation page for the schema incorrectly claims them to be required.

Modify the parser to allow these to be optional when parsing.

Fixes #300