### PR TITLE
release 0.14.13

### DIFF
--- a/svd-encoder/CHANGELOG.md
+++ b/svd-encoder/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.14.8] - 2026-04-15
+## [v0.14.8] - 2026-08-11
 
 - Pin `indexmap` to `2.11.4` to support our MSRV
 - Bump MSRV to 1.84.0

--- a/svd-encoder/CHANGELOG.md
+++ b/svd-encoder/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.14.8] - 2026-04-15
+
 - Pin `indexmap` to `2.11.4` to support our MSRV
 - Bump MSRV to 1.84.0
 - Set `resolver = "3"`, which implies `resolver.incompatible-rust-versions = "fallback"`
@@ -70,7 +72,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Previous versions in common [changelog](../CHANGELOG.md).
 
-[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.12...HEAD
+[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.13...HEAD
+[v0.14.8]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.12...svd-rs-v0.14.13
 [v0.14.7]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.11...svd-rs-v0.14.12
 [v0.14.6]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.9...svd-rs-v0.14.10
 [v0.14.5]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.8...svd-rs-v0.14.9

--- a/svd-encoder/Cargo.toml
+++ b/svd-encoder/Cargo.toml
@@ -8,12 +8,12 @@ name = "svd-encoder"
 repository = "https://github.com/rust-embedded/svd"
 edition = "2021"
 rust-version = "1.84.0"
-version = "0.14.7"
+version = "0.14.8"
 readme = "README.md"
 
 [dependencies]
 convert_case = "0.6.0"
-svd-rs = { version = "0.14.12", path = "../svd-rs" }
+svd-rs = { version = "0.14.13", path = "../svd-rs" }
 thiserror = "1.0.31"
 # This is a transitive dep introduced by XML tree,
 # but we need to pin to this version to support our current MSRV of 1.70.0

--- a/svd-encoder/Cargo.toml
+++ b/svd-encoder/Cargo.toml
@@ -15,9 +15,7 @@ readme = "README.md"
 convert_case = "0.6.0"
 svd-rs = { version = "0.14.13", path = "../svd-rs" }
 thiserror = "1.0.31"
-# This is a transitive dep introduced by XML tree,
-# but we need to pin to this version to support our current MSRV of 1.70.0
-indexmap = "=2.11.4"
+indexmap = "2.13.1"
 
 [dependencies.xmltree]
 version = "0.11.0"

--- a/svd-parser/CHANGELOG.md
+++ b/svd-parser/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.14.10] - 2026-04-15
+## [v0.14.10] - 2026-08-11
 
 - Add `Target` enum to `Config` and make `vendorSystickConfig` only required for ARM.
 - Bump MSRV to 1.84.0

--- a/svd-parser/CHANGELOG.md
+++ b/svd-parser/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.14.10] - 2026-04-15
+
 - Add `Target` enum to `Config` and make `vendorSystickConfig` only required for ARM.
 - Bump MSRV to 1.84.0
 - Set `resolver = "3"`, which implies `resolver.incompatible-rust-versions = "fallback"`
@@ -92,7 +94,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Previous versions in common [changelog](../CHANGELOG.md).
 
-[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.12...HEAD
+[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.13...HEAD
+[v0.14.10]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.12...svd-rs-v0.14.13
 [v0.14.9]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.11...svd-rs-v0.14.12
 [v0.14.8]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.9...svd-rs-v0.14.10
 [v0.14.6]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.8...svd-rs-v0.14.9

--- a/svd-parser/Cargo.toml
+++ b/svd-parser/Cargo.toml
@@ -11,7 +11,7 @@ name = "svd-parser"
 repository = "https://github.com/rust-embedded/svd"
 edition = "2021"
 rust-version = "1.84.0"
-version = "0.14.9"
+version = "0.14.10"
 readme = "README.md"
 
 [features]
@@ -19,7 +19,7 @@ derive-from = ["svd-rs/derive-from"]
 expand = ["derive-from"]
 
 [dependencies]
-svd-rs = { version = "0.14.12", path = "../svd-rs" }
+svd-rs = { version = "0.14.13", path = "../svd-rs" }
 roxmltree = "0.20"
 anyhow = "1.0.58"
 thiserror = "1.0.31"
@@ -27,7 +27,7 @@ thiserror = "1.0.31"
 [dev-dependencies]
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.8.26"
-svd-rs = { version = "0.14.10", path = "../svd-rs", features = ["serde"] }
+svd-rs = { version = "0.14.13", path = "../svd-rs", features = ["serde"] }
 
 [[example]]
 name = "svd2json"

--- a/svd-rs/CHANGELOG.md
+++ b/svd-rs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.14.13] - 2026-04-15
+
 - Bump MSRV to 1.84.0
 - Set `resolver = "3"`, which implies `resolver.incompatible-rust-versions = "fallback"`
 - Allow overriding `dimElementGroup` fields when deriving.
@@ -141,7 +143,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Previous versions in common [changelog](../CHANGELOG.md).
 
-[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.12...HEAD
+[Unreleased]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.13...HEAD
+[v0.14.13]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.12...svd-rs-v0.14.13
 [v0.14.12]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.11...svd-rs-v0.14.12
 [v0.14.11]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.10...svd-rs-v0.14.11
 [v0.14.10]: https://github.com/rust-embedded/svd/compare/svd-rs-v0.14.9...svd-rs-v0.14.10

--- a/svd-rs/CHANGELOG.md
+++ b/svd-rs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.14.13] - 2026-04-15
+## [v0.14.13] - 2026-08-11
 
 - Bump MSRV to 1.84.0
 - Set `resolver = "3"`, which implies `resolver.incompatible-rust-versions = "fallback"`

--- a/svd-rs/Cargo.toml
+++ b/svd-rs/Cargo.toml
@@ -8,7 +8,7 @@ name = "svd-rs"
 repository = "https://github.com/rust-embedded/svd"
 edition = "2021"
 rust-version = "1.84.0"
-version = "0.14.12"
+version = "0.14.13"
 readme = "README.md"
 
 [features]


### PR DESCRIPTION
@Emilgardis all changes look backward compatible.

But this is big MSRV grow. So I'm not sure is this `0.14.13` or `0.15.0`?